### PR TITLE
feat: Overwrite crunz timezone with TZ env on container start

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 # define your env variables for the test env here
 APP_ENV=test
+TZ=Etc/GMT
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ NUMBER_OF_NEW_ACTIVITIES_TO_PROCESS_PER_IMPORT=250
 # The default schedule runs once a day at 04:05. If you do not know what cron expressions are, please leave this unchanged
 # Make sure you don't run the imports too much to avoid hitting the Strava API rate limit. Once a day should be enough.
 IMPORT_AND_BUILD_SCHEDULE="5 4 * * *"
+# The timezone to run the schedule in
+TZ=Etc/GMT
 
 # Allowed options: en_US, fr_FR or nl_BE
 LOCALE=en_US

--- a/crunz_tz.sh
+++ b/crunz_tz.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# usage:
+# crunz_tz.sh /path/to/crunz.yml
+
+#TZ should have a default in Dockerfile and (optionally) be set at container runtime
+TZ="${TZ:-Etc/GMT}"
+
+# replace "timezone: SOMETHING" in crunz.yml with TZ env
+sed -i -e "s!timezone: [^\n\r]*!timezone: $TZ!" $1
+
+echo "Updated crunz with TZ $TZ"

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -61,6 +61,8 @@ RUN rm -Rf docker
 # Expose the port nginx is reachable on
 EXPOSE 8080
 
+ENV TZ=Etc/GMT
+
 # Let supervisord start services
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 

--- a/docker/app/config/supervisord.conf
+++ b/docker/app/config/supervisord.conf
@@ -19,6 +19,17 @@ directory=/var/www
 autostart=true
 autorestart=true
 
+[program:cron-tz]
+command= sh -c "./crunz_tz.sh crunz.yml"
+directory=/var/www
+autostart=true
+autorestart=false
+startsecs=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:nginx]
 command=nginx -g 'daemon off;'
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

Fixes #192 by overwriting `timezone: VALUE` in `crunz.yml` on container start using the value of the ENV `TZ`

## Checklist

- [ ] Added/updated tests?
- [ ] Bumped APP version?

