### PR TITLE
fix: Fix bad permissions on /run

### DIFF
--- a/docker/app/config/conf.d/default.conf
+++ b/docker/app/config/conf.d/default.conf
@@ -46,7 +46,7 @@ server {
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_pass unix:/tmp/php-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_index index.php;
         include fastcgi_params;
@@ -65,6 +65,6 @@ server {
         deny all;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_pass unix:/tmp/php-fpm.sock;
     }
 }

--- a/docker/app/config/fpm-pool.conf
+++ b/docker/app/config/fpm-pool.conf
@@ -13,7 +13,7 @@ error_log = /dev/stderr
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php-fpm.sock
+listen = /tmp/php-fpm.sock
 
 ; Enable status page
 pm.status_path = /fpm-status

--- a/docker/root/etc/s6-overlay/s6-rc.d/init-stravastat-config/run
+++ b/docker/root/etc/s6-overlay/s6-rc.d/init-stravastat-config/run
@@ -1,14 +1,14 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+touch /tmp/php-fpm.sock
+
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     lsiown -R abc:abc \
         /config \
         /var/www \
-        /run \
         /var/lib/nginx \
         /var/log/nginx
 
-    touch /run/php-fpm.sock
-    lsiown abc:abc /run/php-fpm.sock
+    lsiown abc:abc /tmp/php-fpm.sock
 fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

In docker container, fixes `/run` not belonging to `root` on startup due to overzealous `abc` chown'ing and location of `php-fpm.sock`. Makes this warning in log go away

```
/package/admin/s6-overlay/libexec/preinit: info: /run belongs to uid 65534 instead of 0 - fixing it
```

* Move `php-fpm.sock` file to non-root (`/tmp`) directory by `touch` on startup and change paths where it is used
* Don't chown `/run` to `abc`
  * Instead, chown specific path of sock file to `abc`

## Checklist

- [ ] Added/updated tests?
- [ ] Bumped APP version?

