### PR TITLE
Docker Compose example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Start off by showing some ❤️ and give this repo a star. Then from your comma
 services:
   app:
     image: robiningelbrecht/strava-statistics:latest
+    container_name: strava-statistics
+    restart: unless-stopped
     volumes:
       - ./build:/var/www/build
       - ./storage/database:/var/www/storage/database


### PR DESCRIPTION
Added container name and restart "policy" in Docker Compose example

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [x] Documentation Update

## Description

Sets the container name to a default value using `container_name: strava-statistics` and sets a restart "policy" using `restart: unless-stopped` in the Docker Compose example. 

When not set the container will not automaticly start, for example on restart of the host. [Source](https://github.com/compose-spec/compose-spec/blob/main/spec.md#restart)
The default slug makes that the name of the container will be the following: `strava-statistics-strava-statistics-1`
With this change it will be set to: `strava-statistics`

## Checklist

- [ ] Added/updated tests?
- [ ] Bumped APP version?
- [x] Documentation update, so I think above are not applicable. 

