### PR TITLE
Incorrect .env restart instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -45,7 +45,7 @@ services:
 ## .env
 
 <div class="alert important">
-    Every time you change the .env file, you need to restart your container for the changes to take effect.
+    Every time you change the .env file, you need to recreate (for example; docker compose up -d) your container for the changes to take effect (restarting does not update the .env).
 </div>
 
 ```bash

--- a/docs/troubleshooting/strava-authorization.md
+++ b/docs/troubleshooting/strava-authorization.md
@@ -30,7 +30,7 @@ When you have done so, restart your Docker container to apply the changes.
 
 When you encounter an error related to the `client_id`, 
 it usually means that the client ID provided in your `.env` file is incorrect, 
-or you did not restart your Docker container after updating the `.env` file. 
+or you did not recreate your Docker container after updating the `.env` file. 
 Make sure that you have done both of these steps correctly.
 
 ```json


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [x] Documentation Update

## Description

Documentation states "Every time you change the .env file, you need to restart your container for the changes to take effect."
This is wrong, and should state "Every time you change the .env file, you need to **recreate** your container for the changes to take effect."

## Checklist

- [ ] Added/updated tests?
- [ ] Bumped APP version?

