### PR TITLE
ISSUE #1090: Fix unknown `workout_type` values

### DIFF
--- a/src/Domain/Activity/WorkoutType.php
+++ b/src/Domain/Activity/WorkoutType.php
@@ -28,7 +28,8 @@ enum WorkoutType: string implements TranslatableInterface
             1, 11 => self::RACE,
             3, 12 => self::WORKOUT,
             2 => self::LONG_RUN,
-            default => throw new \RuntimeException(sprintf('Workout type "%s" not supported', $workoutType)),
+            // Catch all for unknown values.
+            default => null,
         };
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

Fixes #1090 
Defaults to `null` when `workout_type` value is not recognised.
It doesn't seem like the values are documented in Strava API so couldn't add more mapping there.

I looked at adding some tests, but I'm not sure how to actually run the app and the tests locally 🤔 - A `README` would be a great addition for contribution for those not used to use this stack like me 😄 

## Checklist

- [ ] Added/updated tests?
- [ ] Bumped APP version?

