### PR TITLE
fix(notification): avoid unsupported Shoutrrr params for Telegram

### DIFF
--- a/config/app/test/config.yaml
+++ b/config/app/test/config.yaml
@@ -15,6 +15,7 @@ integrations:
     services:
       - 'ntfy://admin:admin@ntfy.sh/topic'
       - 'discord://token@webhookid?thread_id=123456789'
+      - 'telegram://token@telegram/?channels=channel'
     ntfyUrl: 'https://ntfy.sh/el-test'
     ntfyUsername: admin
     ntfyPassword: pass

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -170,7 +170,7 @@ services:
     App\Domain\Integration\AI\AIProviderFactory:
         arguments: ['@=app_config("integrations.ai", [])']
 
-    App\Domain\Integration\Notification\Shoutrrr\ConfiguredNotificationServices:
+    App\Domain\Integration\Notification\Shoutrrr\ConfiguredNotificationUrls:
       factory: [ null, 'fromConfig' ]
       arguments: [
         '@=app_config("integrations.notifications.services", [])',

--- a/src/Domain/Integration/Notification/SendNotification/SendNotificationCommandHandler.php
+++ b/src/Domain/Integration/Notification/SendNotification/SendNotificationCommandHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Integration\Notification\SendNotification;
 
-use App\Domain\Integration\Notification\Shoutrrr\ConfiguredNotificationServices;
+use App\Domain\Integration\Notification\Shoutrrr\ConfiguredNotificationUrls;
 use App\Domain\Integration\Notification\Shoutrrr\Shoutrrr;
 use App\Domain\Integration\Notification\Shoutrrr\ShoutrrrUrl;
 use App\Infrastructure\CQRS\Command\Command;
@@ -15,7 +15,7 @@ final readonly class SendNotificationCommandHandler implements CommandHandler
 {
     public function __construct(
         private Shoutrrr $shoutrrr,
-        private ConfiguredNotificationServices $configuredNotificationServices,
+        private ConfiguredNotificationUrls $configuredNotificationUrls,
     ) {
     }
 
@@ -23,12 +23,10 @@ final readonly class SendNotificationCommandHandler implements CommandHandler
     {
         assert($command instanceof SendNotification);
 
-        /** @var ShoutrrrUrl $configuredNotificationService */
-        foreach ($this->configuredNotificationServices as $configuredNotificationService) {
-            $shoutrrrUrl = $configuredNotificationService;
-
-            if (!$this->isTelegramUrl($configuredNotificationService)) {
-                $shoutrrrUrl = $configuredNotificationService->withParams([
+        /** @var ShoutrrrUrl $configuredNotificationUrl */
+        foreach ($this->configuredNotificationUrls as $configuredNotificationUrl) {
+            if (!$configuredNotificationUrl->isTelegramUrl()) {
+                $configuredNotificationUrl = $configuredNotificationUrl->withParams([
                     'click' => (string) $command->getActionUrl(),
                     'icon' => 'https://raw.githubusercontent.com/dreeveapp/dreeve/master/public/assets/images/manifest/icon-192.png',
                     'tags' => implode(',', $command->getTags()),
@@ -44,15 +42,10 @@ final readonly class SendNotificationCommandHandler implements CommandHandler
             }
 
             $this->shoutrrr->send(
-                shoutrrrUrl: $shoutrrrUrl,
+                shoutrrrUrl: $configuredNotificationUrl,
                 message: $command->getMessage(),
                 title: $command->getTitle(),
             );
         }
-    }
-
-    private function isTelegramUrl(\Stringable|string $shoutrrrUrl): bool
-    {
-        return str_starts_with((string) $shoutrrrUrl, 'telegram://');
     }
 }

--- a/src/Domain/Integration/Notification/SendNotification/SendNotificationCommandHandler.php
+++ b/src/Domain/Integration/Notification/SendNotification/SendNotificationCommandHandler.php
@@ -10,6 +10,7 @@ use App\Domain\Integration\Notification\Shoutrrr\ShoutrrrUrl;
 use App\Infrastructure\CQRS\Command\Command;
 use App\Infrastructure\CQRS\Command\CommandHandler;
 use App\Infrastructure\Serialization\Json;
+use Stringable;
 
 final readonly class SendNotificationCommandHandler implements CommandHandler
 {
@@ -25,8 +26,10 @@ final readonly class SendNotificationCommandHandler implements CommandHandler
 
         /** @var ShoutrrrUrl $configuredNotificationService */
         foreach ($this->configuredNotificationServices as $configuredNotificationService) {
-            $this->shoutrrr->send(
-                shoutrrrUrl: $configuredNotificationService->withParams([
+            $shoutrrrUrl = $configuredNotificationService;
+
+            if (!$this->isTelegramUrl($configuredNotificationService)) {
+                $shoutrrrUrl = $configuredNotificationService->withParams([
                     'click' => (string) $command->getActionUrl(),
                     'icon' => 'https://raw.githubusercontent.com/dreeveapp/dreeve/master/public/assets/images/manifest/icon-192.png',
                     'tags' => implode(',', $command->getTags()),
@@ -38,10 +41,19 @@ final readonly class SendNotificationCommandHandler implements CommandHandler
                             'clear' => true,
                         ],
                     ]),
-                ]),
+                ]);
+            }
+
+            $this->shoutrrr->send(
+                shoutrrrUrl: $shoutrrrUrl,
                 message: $command->getMessage(),
                 title: $command->getTitle(),
             );
         }
+    }
+
+    private function isTelegramUrl(Stringable|string $shoutrrrUrl): bool
+    {
+        return str_starts_with((string) $shoutrrrUrl, 'telegram://');
     }
 }

--- a/src/Domain/Integration/Notification/SendNotification/SendNotificationCommandHandler.php
+++ b/src/Domain/Integration/Notification/SendNotification/SendNotificationCommandHandler.php
@@ -10,7 +10,6 @@ use App\Domain\Integration\Notification\Shoutrrr\ShoutrrrUrl;
 use App\Infrastructure\CQRS\Command\Command;
 use App\Infrastructure\CQRS\Command\CommandHandler;
 use App\Infrastructure\Serialization\Json;
-use Stringable;
 
 final readonly class SendNotificationCommandHandler implements CommandHandler
 {
@@ -52,7 +51,7 @@ final readonly class SendNotificationCommandHandler implements CommandHandler
         }
     }
 
-    private function isTelegramUrl(Stringable|string $shoutrrrUrl): bool
+    private function isTelegramUrl(\Stringable|string $shoutrrrUrl): bool
     {
         return str_starts_with((string) $shoutrrrUrl, 'telegram://');
     }

--- a/src/Domain/Integration/Notification/Shoutrrr/ConfiguredNotificationUrls.php
+++ b/src/Domain/Integration/Notification/Shoutrrr/ConfiguredNotificationUrls.php
@@ -2,7 +2,7 @@
 
 namespace App\Domain\Integration\Notification\Shoutrrr;
 
-final readonly class ConfiguredNotificationServices implements \IteratorAggregate
+final readonly class ConfiguredNotificationUrls implements \IteratorAggregate
 {
     public function __construct(
         /** @var ShoutrrrUrl[] */
@@ -19,10 +19,10 @@ final readonly class ConfiguredNotificationServices implements \IteratorAggregat
         ?string $ntfyUsername,
         ?string $ntfyPassword): self
     {
-        $configuredNotificationServices = [];
+        $configuredNotificationUrls = [];
         if (!in_array($ntfyUrl, [null, '', '0'], true)) {
             // Make sure feature is BC with old ntfy config.
-            $configuredNotificationServices[] = ShoutrrrUrl::fromDeprecatedNtfyConfig(
+            $configuredNotificationUrls[] = ShoutrrrUrl::fromDeprecatedNtfyConfig(
                 ntfyUrl: $ntfyUrl,
                 ntfyUsername: $ntfyUsername,
                 ntfyPassword: $ntfyPassword
@@ -33,10 +33,10 @@ final readonly class ConfiguredNotificationServices implements \IteratorAggregat
             if (!is_string($notificationService)) {
                 throw new \RuntimeException('Notification service name must be a string');
             }
-            $configuredNotificationServices[] = ShoutrrrUrl::fromString($notificationService);
+            $configuredNotificationUrls[] = ShoutrrrUrl::fromString($notificationService);
         }
 
-        return new self($configuredNotificationServices);
+        return new self($configuredNotificationUrls);
     }
 
     public function getIterator(): \Traversable

--- a/src/Domain/Integration/Notification/Shoutrrr/ShoutrrrUrl.php
+++ b/src/Domain/Integration/Notification/Shoutrrr/ShoutrrrUrl.php
@@ -19,6 +19,11 @@ final readonly class ShoutrrrUrl extends NonEmptyStringLiteral
         return self::fromString(sprintf('%s?%s', $this, http_build_query($params)));
     }
 
+    public function isTelegramUrl(): bool
+    {
+        return str_starts_with((string) $this, 'telegram://');
+    }
+
     public static function fromDeprecatedNtfyConfig(
         string $ntfyUrl,
         ?string $ntfyUsername,

--- a/tests/Domain/Integration/Notification/SendNotification/__snapshots__/SendNotificationCommandHandlerTest__testHandle__1.json
+++ b/tests/Domain/Integration/Notification/SendNotification/__snapshots__/SendNotificationCommandHandlerTest__testHandle__1.json
@@ -13,5 +13,10 @@
         "url": "discord://token@webhookid?thread_id=123456789?click=https%3A%2F%2Flocalhost&icon=https%3A%2F%2Fraw.githubusercontent.com%2Fdreeveapp%2Fdreeve%2Fmaster%2Fpublic%2Fassets%2Fimages%2Fmanifest%2Ficon-192.png&tags=tag1%2Ctag2&actions=%5B%7B%22action%22%3A%22view%22%2C%22label%22%3A%22Open+app%22%2C%22url%22%3A%22https%3A%5C%2F%5C%2Flocalhost%22%2C%22clear%22%3Atrue%7D%5D",
         "message": "le message",
         "title": "le title"
+    },
+    {
+        "url": "telegram://token@telegram/?channels=channel",
+        "message": "le message",
+        "title": "le title"
     }
 ]

--- a/tests/Domain/Integration/Notification/Shoutrrr/ConfiguredNotificationUrlsTest.php
+++ b/tests/Domain/Integration/Notification/Shoutrrr/ConfiguredNotificationUrlsTest.php
@@ -2,11 +2,11 @@
 
 namespace App\Tests\Domain\Integration\Notification\Shoutrrr;
 
-use App\Domain\Integration\Notification\Shoutrrr\ConfiguredNotificationServices;
+use App\Domain\Integration\Notification\Shoutrrr\ConfiguredNotificationUrls;
 use App\Domain\Integration\Notification\Shoutrrr\ShoutrrrUrl;
 use PHPUnit\Framework\TestCase;
 
-class ConfiguredNotificationServicesTest extends TestCase
+class ConfiguredNotificationUrlsTest extends TestCase
 {
     public function testFromConfig(): void
     {
@@ -16,7 +16,7 @@ class ConfiguredNotificationServicesTest extends TestCase
                 ShoutrrrUrl::fromString('ntfy://admin:admin@ntfy.sh/topic'),
                 ShoutrrrUrl::fromString('discord://token@webhookid?thread_id=123456789'),
             ],
-            iterator_to_array(ConfiguredNotificationServices::fromConfig(
+            iterator_to_array(ConfiguredNotificationUrls::fromConfig(
                 config: [
                     'ntfy://admin:admin@ntfy.sh/topic',
                     'discord://token@webhookid?thread_id=123456789',
@@ -32,7 +32,7 @@ class ConfiguredNotificationServicesTest extends TestCase
     {
         $this->expectExceptionObject(new \RuntimeException('Notification service name must be a string'));
 
-        ConfiguredNotificationServices::fromConfig(
+        ConfiguredNotificationUrls::fromConfig(
             config: [
                 [],
             ],


### PR DESCRIPTION
Telegram Shoutrrr URLs fail when the generic notification parameters (`click`, `icon`, `tags`, `actions`) are appended.

This keeps those richer parameters for providers that support them, but sends the configured Telegram URL as-is.

Validated locally on v4.8.8 aggregate build:
- Docker image rebuild succeeded
- app + daemon healthy
- app reports v4.8.8
- notification handler passes PHP syntax check