### PR TITLE
Add an HTTP API for configuration management

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,10 @@ STRAVA_REFRESH_TOKEN=replace-me
 BLACKFIRE_CLIENT_ID=replace-me
 BLACKFIRE_CLIENT_TOKEN=replace-me
 
+# Enables the configuration API when set. Minimum 32 characters.
+# See https://docs.dreeve.app/#/integrations/api
+#API_TOKEN=
+
 #ADMIN_ALLOWED_IPS=
 #PUID=1000
 #PGID=1000

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,6 +14,13 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        api:
+            # Must be declared before `main`: firewalls match in order and `main`
+            # has no pattern, so it would otherwise swallow API requests.
+            pattern: ^/api/v1/
+            stateless: true
+            custom_authenticator: App\Infrastructure\Security\ApiTokenAuthenticator
+
         main:
             lazy: true
             provider: admin_provider
@@ -34,6 +41,7 @@ security:
     # Note: Only the *first* matching rule is applied.
     # The ^/admin/login PUBLIC_ACCESS rule must precede ^/admin to avoid a redirect loop.
     access_control:
+        - { path: ^/api/v1/, roles: ROLE_API }
         - { path: ^/admin/login, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,6 +9,7 @@ parameters:
     env(ADMIN_USERNAME): 'admin'
     env(ADMIN_PASSWORD_HASH): ''
     env(ADMIN_ALLOWED_IPS): ''
+    env(API_TOKEN): ''
     env(STRAVA_CLIENT_ID): 'replace-me'
     env(STRAVA_CLIENT_SECRET): 'replace-me'
     env(STRAVA_REFRESH_TOKEN): 'replace-me'
@@ -64,6 +65,10 @@ services:
     App\Infrastructure\Config\AdminAllowedIpAddresses:
         factory: [ null, 'fromString' ]
         arguments: ['%env(string:ADMIN_ALLOWED_IPS)%']
+
+    App\Infrastructure\Config\ApiToken:
+        factory: [ null, 'fromString' ]
+        arguments: ['%env(string:API_TOKEN)%']
 
     App\Infrastructure\Config\DemoMode:
         factory: [ null, 'fromString' ]

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -17,6 +17,7 @@
 
   - [AI assistant](integrations/ai.md "Dreeve | AI assistant")
   - [Notifications](integrations/notifications.md "Dreeve | Notifications")
+  - [Configuration API](integrations/api.md "Dreeve | Configuration API")
 
 - Troubleshooting
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -96,8 +96,13 @@ ADMIN_USERNAME=admin
 # See the "Admin password" section below.
 ADMIN_PASSWORD_HASH='replace-me'
 
-# Takes a comma-separated allowlist. When it is set, requests to /admin* from any other IP are rejected.
+# Takes a comma-separated allowlist. When it is set, requests to /admin* and to
+# the configuration API from any other IP are rejected.
 # ADMIN_ALLOWED_IPS=192.168.1.10,192.168.1.11
+
+# Enables the configuration API, which is off unless this is set.
+# Minimum 32 characters. See https://docs.dreeve.app/#/integrations/api
+# API_TOKEN=
 
 # Only needed when IMPORT_MODE=stravaApi.
 # See https://docs.dreeve.app/#/importing/strava-import

--- a/docs/integrations/api.md
+++ b/docs/integrations/api.md
@@ -1,0 +1,258 @@
+# Configuration API
+
+Dreeve exposes a small HTTP API for reading and updating configuration, so
+settings that come from an external source — a smart scale, a health export, a
+coaching spreadsheet — can be kept in sync without anyone opening the admin
+panel.
+
+The API is **disabled by default**. It only starts accepting requests once you
+set `API_TOKEN`.
+
+## Enabling the API
+
+Generate a long random token and add it to your `.env`:
+
+```bash
+# At least 32 characters. Anything shorter is rejected on startup.
+API_TOKEN=$(openssl rand -hex 32)
+```
+
+```bash
+API_TOKEN=1f1d1b0a...  # your generated value
+```
+
+Then recreate the containers so the new value is picked up:
+
+```bash
+> docker compose up -d
+```
+
+> [!WARNING]
+> The token grants full read/write access to your configuration. Treat it like a
+> password: keep it out of version control, and prefer serving Dreeve over HTTPS
+> if it is reachable outside your network.
+
+`ADMIN_ALLOWED_IPS` applies to the API as well as the admin panel, so the same
+setting restricts both routes into your configuration:
+
+```bash
+ADMIN_ALLOWED_IPS=192.168.1.10,192.168.1.11
+```
+
+Requests from any other address get a `404`, the same way the admin panel is
+concealed.
+
+## Authentication
+
+Every request needs a bearer token:
+
+```bash
+> curl -H "Authorization: Bearer $API_TOKEN" \
+       http://localhost:8080/api/v1/config
+```
+
+Missing, malformed or incorrect tokens get a `401` with a JSON body:
+
+```json
+{ "message": "Invalid API token." }
+```
+
+## Discovering what is available
+
+`GET /api/v1/config` lists every resource this version exposes:
+
+```json
+{
+  "resources": [
+    { "name": "athlete/ftp-history/cycling",   "href": "/api/v1/config/athlete/ftp-history/cycling",   "methods": ["GET", "PUT"] },
+    { "name": "athlete/ftp-history/running",   "href": "/api/v1/config/athlete/ftp-history/running",   "methods": ["GET", "PUT"] },
+    { "name": "athlete/max-heart-rate",        "href": "/api/v1/config/athlete/max-heart-rate",        "methods": ["GET", "PUT"] },
+    { "name": "athlete/resting-heart-rate",    "href": "/api/v1/config/athlete/resting-heart-rate",    "methods": ["GET", "PUT"] },
+    { "name": "athlete/weight-history",        "href": "/api/v1/config/athlete/weight-history",        "methods": ["GET", "PUT"] },
+    { "name": "zwift",                         "href": "/api/v1/config/zwift",                         "methods": ["GET", "PUT"] }
+  ]
+}
+```
+
+`GET` reads the current value; `PUT` replaces it and responds with the stored
+state, so you can confirm what was persisted without a second request. Always
+check `methods` rather than assuming: a resource may be read-only, in which case
+`PUT` returns `405`.
+
+`PUT` **replaces** the whole collection rather than appending to it — send the
+full history every time.
+
+## Weight history
+
+```bash
+> curl -H "Authorization: Bearer $API_TOKEN" \
+       http://localhost:8080/api/v1/config/athlete/weight-history
+```
+
+```json
+{
+  "unit": "kg",
+  "entries": [
+    { "on": "2024-01-01", "weight": 70.5 },
+    { "on": "2024-06-01", "weight": 69 }
+  ]
+}
+```
+
+Weights are stored as plain numbers and interpreted using the unit system from
+**Settings → Appearance** — `kg` when metric, `lb` when imperial. The `unit`
+field is returned so a client can tell which one is in effect.
+
+To update:
+
+```bash
+> curl -X PUT \
+       -H "Authorization: Bearer $API_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"unit": "kg", "entries": [{"on": "2024-01-01", "weight": 70.5}]}' \
+       http://localhost:8080/api/v1/config/athlete/weight-history
+```
+
+`unit` is optional, but sending it is recommended: if it disagrees with the
+configured unit system the request is rejected instead of silently writing
+pounds into a kilogram history.
+
+## FTP history
+
+FTP is tracked separately per sport, so each has its own resource:
+
+```bash
+> curl -X PUT \
+       -H "Authorization: Bearer $API_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"entries": [{"on": "2025-01-01", "ftp": 300}]}' \
+       http://localhost:8080/api/v1/config/athlete/ftp-history/cycling
+```
+
+```json
+{
+  "sport": "cycling",
+  "entries": [{ "on": "2025-01-01", "ftp": 300 }]
+}
+```
+
+Updating one sport never affects the other. The sport is taken from the URL, so
+a `sport` field in the body is ignored.
+
+## Heart rate
+
+Max heart rate is either a named formula or values you measured, discriminated
+by `type`:
+
+```bash
+> curl -X PUT \
+       -H "Authorization: Bearer $API_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"type": "formula", "formula": "fox"}' \
+       http://localhost:8080/api/v1/config/athlete/max-heart-rate
+```
+
+Allowed formulas: `arena`, `astrand`, `fox`, `gellish`, `nes`, `tanaka`.
+
+Measured values apply from their date onwards:
+
+```json
+{
+  "type": "measured",
+  "entries": [
+    { "on": "2020-01-01", "bpm": 198 },
+    { "on": "2025-01-10", "bpm": 193 }
+  ]
+}
+```
+
+Resting heart rate works the same way, with a third option for a single fixed
+value:
+
+```json
+{ "type": "formula", "formula": "heuristicAgeBased" }
+{ "type": "fixed",   "bpm": 52 }
+{ "type": "measured", "entries": [{ "on": "2024-01-01", "bpm": 54 }] }
+```
+
+A date may appear only once per history, and every `bpm` must be a whole number
+above zero.
+
+## Zwift
+
+```bash
+> curl -X PUT \
+       -H "Authorization: Bearer $API_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"level": 42, "racingScore": 495}' \
+       http://localhost:8080/api/v1/config/zwift
+```
+
+Either field may be `null` to clear it.
+
+## Rebuilds
+
+Weight, FTP and heart rate feed derived metrics such as w/kg, heart rate zones
+and stress level, so a successful update flags the app for a rebuild. The daemon container picks that
+up within a few minutes and regenerates the affected pages. Nothing extra to
+call.
+
+## Errors
+
+| Status | Meaning |
+|--------|---------|
+| `400`  | The body was not valid JSON, or a value was rejected. `message` says which entry and why. |
+| `401`  | Missing, malformed or incorrect token, or `API_TOKEN` is not set. |
+| `404`  | No such configuration resource, or your IP is not in `ADMIN_ALLOWED_IPS`. |
+| `405`  | The resource is read-only. |
+
+Validation is all-or-nothing: if any entry is rejected, nothing is written.
+
+```json
+{ "message": "Entry #2 is missing a valid numeric \"weight\"." }
+```
+
+## Adding a new resource
+
+The endpoint list is not hardcoded in the controller. Implement
+`App\Domain\Settings\Api\ConfigResource` and the class is picked up
+automatically through the `app.api.config_resource` tag:
+
+```php
+final readonly class MyConfigResource implements ConfigResource
+{
+    public function getName(): string
+    {
+        return 'my/resource';
+    }
+
+    public function read(): array
+    {
+        // Current value, as returned by GET. Never return secrets: anything
+        // here is visible to every client holding an API token.
+    }
+}
+```
+
+That gives you a read-only endpoint. To accept `PUT` as well, implement
+`WritableConfigResource` instead:
+
+```php
+final readonly class MyConfigResource implements WritableConfigResource
+{
+    // getName() and read() as above.
+
+    public function buildUpdateCommand(array $payload): Command
+    {
+        // Validate, then return a command without mutating anything. Throw
+        // CouldNotDeserializeCommand::invalidPayload() to produce a 400.
+    }
+}
+```
+
+The command can be an existing one — `ZwiftConfigResource` returns
+`UpdateSettings` rather than defining its own. Mark it `#[RequiresRebuild]` if
+the setting feeds anything the app renders.
+
+No routing or controller changes are required — the resource shows up in
+`GET /api/v1/config` and becomes addressable at `/api/v1/config/my/resource`.

--- a/src/Controller/Api/ConfigApiRequestHandler.php
+++ b/src/Controller/Api/ConfigApiRequestHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Domain\Settings\Api\ConfigResource;
+use App\Domain\Settings\Api\ConfigResourceRegistry;
+use App\Domain\Settings\Api\CouldNotResolveConfigResource;
+use App\Domain\Settings\Api\WritableConfigResource;
+use App\Infrastructure\CQRS\Command\Bus\CommandBus;
+use App\Infrastructure\CQRS\Command\CouldNotProcessCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\Http\HttpStatusCode;
+use App\Infrastructure\Http\JsonErrorResponse;
+use App\Infrastructure\Serialization\Json;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Read/write HTTP API over the app's configuration.
+ *
+ * Endpoints are not enumerated here: every service tagged
+ * "app.api.config_resource" is exposed automatically, so adding configuration to
+ * the API means adding one ConfigResource implementation and nothing else.
+ *
+ * Routes need a priority above ApiRequestHandler's catch-all /api/{path}.
+ */
+#[AsController]
+final readonly class ConfigApiRequestHandler
+{
+    private const int ROUTE_PRIORITY = 5;
+
+    public function __construct(
+        private ConfigResourceRegistry $configResourceRegistry,
+        private CommandBus $commandBus,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    #[Route(path: '/api/v1/config', name: 'api_config_index', methods: ['GET'], priority: self::ROUTE_PRIORITY)]
+    public function index(): JsonResponse
+    {
+        return new JsonResponse([
+            'resources' => array_map(
+                fn (ConfigResource $configResource): array => [
+                    'name' => $configResource->getName(),
+                    'href' => $this->hrefFor($configResource->getName()),
+                    'methods' => $this->methodsFor($configResource),
+                ],
+                $this->configResourceRegistry->findAll()
+            ),
+        ]);
+    }
+
+    #[Route(path: '/api/v1/config/{resource}', name: 'api_config_read', requirements: ['resource' => '.+'], methods: ['GET'], priority: self::ROUTE_PRIORITY)]
+    public function read(string $resource): Response
+    {
+        try {
+            $configResource = $this->configResourceRegistry->resolve($resource);
+        } catch (CouldNotResolveConfigResource $e) {
+            return $this->error($e, HttpStatusCode::NOT_FOUND);
+        }
+
+        return new JsonResponse($configResource->read());
+    }
+
+    #[Route(path: '/api/v1/config/{resource}', name: 'api_config_update', requirements: ['resource' => '.+'], methods: ['PUT'], priority: self::ROUTE_PRIORITY)]
+    public function update(string $resource, Request $request): Response
+    {
+        try {
+            $configResource = $this->configResourceRegistry->resolve($resource);
+        } catch (CouldNotResolveConfigResource $e) {
+            return $this->error($e, HttpStatusCode::NOT_FOUND);
+        }
+
+        if (!$configResource instanceof WritableConfigResource) {
+            $response = new JsonErrorResponse(
+                ['message' => sprintf('Configuration resource "%s" is read-only.', $resource)],
+                HttpStatusCode::METHOD_NOT_ALLOWED->value
+            );
+            $response->headers->set('Allow', 'GET');
+
+            return $response;
+        }
+
+        try {
+            $payload = Json::decode($request->getContent());
+        } catch (\JsonException $e) {
+            return $this->error($e, HttpStatusCode::BAD_REQUEST);
+        }
+
+        if (!is_array($payload)) {
+            return new JsonErrorResponse(['message' => 'Request body must be a JSON object.'], HttpStatusCode::BAD_REQUEST->value);
+        }
+
+        try {
+            /* @var array<string, mixed> $payload */
+            $this->commandBus->dispatch($configResource->buildUpdateCommand($payload));
+        } catch (CouldNotDeserializeCommand|CouldNotProcessCommand $e) {
+            return $this->error($e, HttpStatusCode::BAD_REQUEST);
+        }
+
+        // Echo the stored state back, so a client can confirm what was persisted
+        // without a follow-up request.
+        return new JsonResponse($configResource->read());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function methodsFor(ConfigResource $configResource): array
+    {
+        return $configResource instanceof WritableConfigResource ? ['GET', 'PUT'] : ['GET'];
+    }
+
+    private function hrefFor(string $resourceName): string
+    {
+        return $this->urlGenerator->generate('api_config_read', ['resource' => $resourceName]);
+    }
+
+    private function error(\Throwable $exception, HttpStatusCode $statusCode): JsonErrorResponse
+    {
+        return new JsonErrorResponse(['message' => $exception->getMessage()], $statusCode->value);
+    }
+}

--- a/src/Domain/Ftp/FtpHistory.php
+++ b/src/Domain/Ftp/FtpHistory.php
@@ -11,9 +11,6 @@ use App\Infrastructure\ValueObject\Time\SerializableDateTime;
 
 final class FtpHistory implements SupportsAITooling
 {
-    private const string CYCLING_KEY = 'cycling';
-    private const string RUNNING_KEY = 'running';
-
     /** @var array<string, Ftp[]> */
     private array $ftps;
 
@@ -23,11 +20,11 @@ final class FtpHistory implements SupportsAITooling
     private function __construct(
         array $ftps,
     ) {
-        $this->ftps[self::CYCLING_KEY] = $this->mapFtpHistory(is_array($ftps[self::CYCLING_KEY] ?? null) ? $ftps[self::CYCLING_KEY] : [], self::CYCLING_KEY);
-        $this->ftps[self::RUNNING_KEY] = $this->mapFtpHistory(is_array($ftps[self::RUNNING_KEY] ?? null) ? $ftps[self::RUNNING_KEY] : [], self::RUNNING_KEY);
+        $this->ftps[FtpSport::CYCLING->value] = $this->mapFtpHistory(is_array($ftps[FtpSport::CYCLING->value] ?? null) ? $ftps[FtpSport::CYCLING->value] : [], FtpSport::CYCLING->value);
+        $this->ftps[FtpSport::RUNNING->value] = $this->mapFtpHistory(is_array($ftps[FtpSport::RUNNING->value] ?? null) ? $ftps[FtpSport::RUNNING->value] : [], FtpSport::RUNNING->value);
 
-        krsort($this->ftps[self::CYCLING_KEY]);
-        krsort($this->ftps[self::RUNNING_KEY]);
+        krsort($this->ftps[FtpSport::CYCLING->value]);
+        krsort($this->ftps[FtpSport::RUNNING->value]);
     }
 
     /**
@@ -60,8 +57,8 @@ final class FtpHistory implements SupportsAITooling
     public function findAll(ActivityType $activityType): Ftps
     {
         $ftps = match ($activityType) {
-            ActivityType::RIDE => $this->ftps[self::CYCLING_KEY],
-            ActivityType::RUN => $this->ftps[self::RUNNING_KEY],
+            ActivityType::RIDE => $this->ftps[FtpSport::CYCLING->value],
+            ActivityType::RUN => $this->ftps[FtpSport::RUNNING->value],
             default => throw new \RuntimeException(sprintf('ActivityType "%s" does not support FTP', $activityType->value)),
         };
 
@@ -75,8 +72,8 @@ final class FtpHistory implements SupportsAITooling
     {
         $on = SerializableDateTime::fromString($on->format('Y-m-d'));
         $ftps = match ($activityType) {
-            ActivityType::RIDE => $this->ftps[self::CYCLING_KEY],
-            ActivityType::RUN => $this->ftps[self::RUNNING_KEY],
+            ActivityType::RIDE => $this->ftps[FtpSport::CYCLING->value],
+            ActivityType::RUN => $this->ftps[FtpSport::RUNNING->value],
             default => throw new \RuntimeException(sprintf('ActivityType "%s" does not support FTP', $activityType->value)),
         };
 
@@ -110,10 +107,10 @@ final class FtpHistory implements SupportsAITooling
      */
     public static function fromArray(array $values): self
     {
-        if (!array_key_exists(self::CYCLING_KEY, $values) && !array_key_exists(self::RUNNING_KEY, $values)) {
+        if (!array_key_exists(FtpSport::CYCLING->value, $values) && !array_key_exists(FtpSport::RUNNING->value, $values)) {
             // This is still an old FTP history when we didn't
             // differentiate between cycling and running yet. Make sure it's BC.
-            $values[self::CYCLING_KEY] = $values;
+            $values[FtpSport::CYCLING->value] = $values;
         }
 
         /* @var array<string, array<string, int>> $values */

--- a/src/Domain/Ftp/FtpSport.php
+++ b/src/Domain/Ftp/FtpSport.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Ftp;
+
+enum FtpSport: string
+{
+    case CYCLING = 'cycling';
+    case RUNNING = 'running';
+}

--- a/src/Domain/Settings/Api/ConfigResource.php
+++ b/src/Domain/Settings/Api/ConfigResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A single addressable piece of configuration, exposed over the HTTP API.
+ *
+ * Implement this interface to add a new endpoint: the class is picked up
+ * automatically through the "app.api.config_resource" tag and becomes
+ * readable at /api/v1/config/{name}. No controller or routing changes needed.
+ *
+ * This interface is read-only. Implement WritableConfigResource as well to
+ * accept PUT.
+ */
+#[AutoconfigureTag('app.api.config_resource')]
+interface ConfigResource
+{
+    /**
+     * Path segment this resource is addressable under, relative to
+     * /api/v1/config. May contain slashes, e.g. "athlete/weight-history".
+     */
+    public function getName(): string;
+
+    /**
+     * Current value, as returned by GET and echoed back by a successful PUT.
+     *
+     * Must not expose secrets: everything returned here is visible to any
+     * client holding an API token.
+     *
+     * @return array<string, mixed>
+     */
+    public function read(): array;
+}

--- a/src/Domain/Settings/Api/ConfigResourceRegistry.php
+++ b/src/Domain/Settings/Api/ConfigResourceRegistry.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+final readonly class ConfigResourceRegistry
+{
+    /**
+     * @param iterable<ConfigResource> $configResources
+     */
+    public function __construct(
+        #[AutowireIterator('app.api.config_resource')]
+        private iterable $configResources,
+    ) {
+    }
+
+    /**
+     * @throws CouldNotResolveConfigResource
+     */
+    public function resolve(string $name): ConfigResource
+    {
+        foreach ($this->configResources as $configResource) {
+            if ($configResource->getName() === $name) {
+                return $configResource;
+            }
+        }
+
+        throw CouldNotResolveConfigResource::withName($name);
+    }
+
+    /**
+     * @return list<ConfigResource>
+     */
+    public function findAll(): array
+    {
+        $configResources = [...$this->configResources];
+        usort($configResources, fn (ConfigResource $a, ConfigResource $b): int => strcmp($a->getName(), $b->getName()));
+
+        return $configResources;
+    }
+}

--- a/src/Domain/Settings/Api/CouldNotResolveConfigResource.php
+++ b/src/Domain/Settings/Api/CouldNotResolveConfigResource.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api;
+
+final class CouldNotResolveConfigResource extends \RuntimeException
+{
+    public static function withName(string $name): self
+    {
+        return new self(sprintf('Configuration resource "%s" does not exist.', $name));
+    }
+}

--- a/src/Domain/Settings/Api/Resource/AthleteCyclingFtpHistoryConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/AthleteCyclingFtpHistoryConfigResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Ftp\FtpSport;
+
+final readonly class AthleteCyclingFtpHistoryConfigResource extends AthleteFtpHistoryConfigResource
+{
+    #[\Override]
+    protected function sport(): FtpSport
+    {
+        return FtpSport::CYCLING;
+    }
+}

--- a/src/Domain/Settings/Api/Resource/AthleteFtpHistoryConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/AthleteFtpHistoryConfigResource.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Ftp\FtpSport;
+use App\Domain\Settings\Api\WritableConfigResource;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Domain\Settings\UpdateAthleteFtpHistory\UpdateAthleteFtpHistory;
+use App\Infrastructure\CQRS\Command\Command;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+abstract readonly class AthleteFtpHistoryConfigResource implements WritableConfigResource
+{
+    public function __construct(
+        // Deliberately the uncached repository: command handlers write through it
+        // too, so reading the state back straight after a write would otherwise
+        // hit a stale CachingSettingsRepository::find() entry.
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    abstract protected function sport(): FtpSport;
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'athlete/ftp-history/'.$this->sport()->value;
+    }
+
+    #[\Override]
+    public function read(): array
+    {
+        $general = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        $athlete = is_array($general['athlete'] ?? null) ? $general['athlete'] : [];
+        $ftpHistory = is_array($athlete['ftpHistory'] ?? null) ? $athlete['ftpHistory'] : [];
+
+        $entries = $ftpHistory[$this->sport()->value] ?? null;
+        if (!is_array($entries)) {
+            // A history predating the cycling/running split is a bare list, which
+            // FtpHistory reads as cycling. Mirror that here so GET matches
+            // whatever the app actually uses.
+            $isLegacyShape = !array_key_exists(FtpSport::CYCLING->value, $ftpHistory)
+                && !array_key_exists(FtpSport::RUNNING->value, $ftpHistory);
+
+            $entries = $isLegacyShape && FtpSport::CYCLING === $this->sport() ? $ftpHistory : [];
+        }
+
+        return [
+            'sport' => $this->sport()->value,
+            'entries' => array_values($entries),
+        ];
+    }
+
+    #[\Override]
+    public function buildUpdateCommand(array $payload): Command
+    {
+        // The sport comes from the URL, not the body, so a client cannot address
+        // one resource and write another.
+        $payload['sport'] = $this->sport()->value;
+
+        return UpdateAthleteFtpHistory::fromPayload($payload);
+    }
+}

--- a/src/Domain/Settings/Api/Resource/AthleteMaxHeartRateConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/AthleteMaxHeartRateConfigResource.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Settings\Api\WritableConfigResource;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Domain\Settings\UpdateAthleteMaxHeartRate\UpdateAthleteMaxHeartRate;
+use App\Infrastructure\CQRS\Command\Command;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class AthleteMaxHeartRateConfigResource implements WritableConfigResource
+{
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'athlete/max-heart-rate';
+    }
+
+    #[\Override]
+    public function read(): array
+    {
+        $general = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        $athlete = is_array($general['athlete'] ?? null) ? $general['athlete'] : [];
+        $formula = $athlete['maxHeartRateFormula'] ?? null;
+
+        if (is_array($formula)) {
+            return [
+                'type' => UpdateAthleteMaxHeartRate::TYPE_MEASURED,
+                'entries' => HeartRateRanges::toEntries($formula),
+            ];
+        }
+
+        return [
+            'type' => UpdateAthleteMaxHeartRate::TYPE_FORMULA,
+            'formula' => is_string($formula) ? $formula : null,
+        ];
+    }
+
+    #[\Override]
+    public function buildUpdateCommand(array $payload): Command
+    {
+        return UpdateAthleteMaxHeartRate::fromPayload($payload);
+    }
+}

--- a/src/Domain/Settings/Api/Resource/AthleteRestingHeartRateConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/AthleteRestingHeartRateConfigResource.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Settings\Api\WritableConfigResource;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Domain\Settings\UpdateAthleteRestingHeartRate\UpdateAthleteRestingHeartRate;
+use App\Infrastructure\CQRS\Command\Command;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class AthleteRestingHeartRateConfigResource implements WritableConfigResource
+{
+    private const string DEFAULT_FORMULA = 'heuristicAgeBased';
+
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'athlete/resting-heart-rate';
+    }
+
+    #[\Override]
+    public function read(): array
+    {
+        $general = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        $athlete = is_array($general['athlete'] ?? null) ? $general['athlete'] : [];
+        $formula = $athlete['restingHeartRateFormula'] ?? self::DEFAULT_FORMULA;
+
+        if (is_array($formula)) {
+            return [
+                'type' => UpdateAthleteRestingHeartRate::TYPE_MEASURED,
+                'entries' => HeartRateRanges::toEntries($formula),
+            ];
+        }
+
+        // A stored numeric, whether int or numeric string, is a fixed value.
+        if (is_int($formula) || (is_string($formula) && ctype_digit($formula))) {
+            return [
+                'type' => UpdateAthleteRestingHeartRate::TYPE_FIXED,
+                'bpm' => (int) $formula,
+            ];
+        }
+
+        return [
+            'type' => UpdateAthleteRestingHeartRate::TYPE_FORMULA,
+            'formula' => is_string($formula) ? $formula : self::DEFAULT_FORMULA,
+        ];
+    }
+
+    #[\Override]
+    public function buildUpdateCommand(array $payload): Command
+    {
+        return UpdateAthleteRestingHeartRate::fromPayload($payload);
+    }
+}

--- a/src/Domain/Settings/Api/Resource/AthleteRunningFtpHistoryConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/AthleteRunningFtpHistoryConfigResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Ftp\FtpSport;
+
+final readonly class AthleteRunningFtpHistoryConfigResource extends AthleteFtpHistoryConfigResource
+{
+    #[\Override]
+    protected function sport(): FtpSport
+    {
+        return FtpSport::RUNNING;
+    }
+}

--- a/src/Domain/Settings/Api/Resource/AthleteWeightHistoryConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/AthleteWeightHistoryConfigResource.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Settings\Api\WritableConfigResource;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Domain\Settings\UpdateAthleteWeightHistory\UpdateAthleteWeightHistory;
+use App\Infrastructure\CQRS\Command\Command;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\ValueObject\Measurement\UnitSystem;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class AthleteWeightHistoryConfigResource implements WritableConfigResource
+{
+    public function __construct(
+        // Deliberately the uncached repository: command handlers write through it
+        // too, so reading the state back straight after a write would otherwise
+        // hit a stale CachingSettingsRepository::find() entry.
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'athlete/weight-history';
+    }
+
+    #[\Override]
+    public function read(): array
+    {
+        $general = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        $athlete = is_array($general['athlete'] ?? null) ? $general['athlete'] : [];
+        $entries = is_array($athlete['weightHistory'] ?? null) ? $athlete['weightHistory'] : [];
+
+        return [
+            'unit' => $this->configuredUnit(),
+            'entries' => array_values($entries),
+        ];
+    }
+
+    #[\Override]
+    public function buildUpdateCommand(array $payload): Command
+    {
+        $this->guardUnit($payload);
+
+        return UpdateAthleteWeightHistory::fromPayload($payload);
+    }
+
+    /**
+     * Stored weights are plain numbers whose meaning depends on the configured
+     * unit system, so a client that assumes the wrong one would silently write
+     * pounds into a kilogram history. Callers may pin the unit they are sending;
+     * if it disagrees with the app, refuse rather than corrupt the history.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function guardUnit(array $payload): void
+    {
+        if (!array_key_exists('unit', $payload)) {
+            return;
+        }
+
+        $unit = $payload['unit'];
+        if (!is_string($unit) || $unit !== $this->configuredUnit()) {
+            throw CouldNotDeserializeCommand::invalidPayload(sprintf('Weights are stored in "%s" because the app is configured to use the %s unit system. Send matching values and either omit "unit" or set it to "%s".', $this->configuredUnit(), $this->settingsRepository->appearance()->getUnitSystem()->value, $this->configuredUnit()));
+        }
+    }
+
+    private function configuredUnit(): string
+    {
+        return UnitSystem::IMPERIAL === $this->settingsRepository->appearance()->getUnitSystem() ? 'lb' : 'kg';
+    }
+}

--- a/src/Domain/Settings/Api/Resource/HeartRateRanges.php
+++ b/src/Domain/Settings/Api/Resource/HeartRateRanges.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+/**
+ * Heart rate histories are stored as a date => bpm map, but the API speaks in
+ * lists of objects so it stays consistent with the weight and FTP resources.
+ */
+final readonly class HeartRateRanges
+{
+    /**
+     * @param array<int|string, mixed> $ranges
+     *
+     * @return list<array{on: string, bpm: int}>
+     */
+    public static function toEntries(array $ranges): array
+    {
+        $entries = [];
+        foreach ($ranges as $on => $bpm) {
+            if (!is_numeric($bpm)) {
+                continue;
+            }
+            $entries[] = ['on' => (string) $on, 'bpm' => (int) $bpm];
+        }
+
+        return $entries;
+    }
+}

--- a/src/Domain/Settings/Api/Resource/ZwiftConfigResource.php
+++ b/src/Domain/Settings/Api/Resource/ZwiftConfigResource.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api\Resource;
+
+use App\Domain\Settings\Api\WritableConfigResource;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Domain\Settings\UpdateSettings\UpdateSettings;
+use App\Infrastructure\CQRS\Command\Command;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Shows that a resource does not need a bespoke command: this one wraps the
+ * existing UpdateSettings, which already replaces a whole settings group.
+ */
+final readonly class ZwiftConfigResource implements WritableConfigResource
+{
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'zwift';
+    }
+
+    #[\Override]
+    public function read(): array
+    {
+        $zwift = $this->settingsRepository->find(SettingsGroup::ZWIFT);
+
+        return [
+            'level' => $this->toOptionalInt($zwift['level'] ?? null),
+            'racingScore' => $this->toOptionalInt($zwift['racingScore'] ?? null),
+        ];
+    }
+
+    #[\Override]
+    public function buildUpdateCommand(array $payload): Command
+    {
+        foreach (['level', 'racingScore'] as $field) {
+            $value = $payload[$field] ?? null;
+            if (null !== $value && !is_numeric($value)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('"%s" must be a number or null.', $field));
+            }
+        }
+
+        return UpdateSettings::fromPayload([
+            'group' => SettingsGroup::ZWIFT->value,
+            'data' => [
+                'level' => $payload['level'] ?? null,
+                'racingScore' => $payload['racingScore'] ?? null,
+            ],
+        ]);
+    }
+
+    private function toOptionalInt(mixed $value): ?int
+    {
+        return is_numeric($value) ? (int) $value : null;
+    }
+}

--- a/src/Domain/Settings/Api/WritableConfigResource.php
+++ b/src/Domain/Settings/Api/WritableConfigResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Api;
+
+use App\Infrastructure\CQRS\Command\Command;
+
+/**
+ * A ConfigResource that also accepts PUT.
+ *
+ * Kept separate from ConfigResource so a resource can be exposed read-only,
+ * for instance one that reports state a client should not be able to change,
+ * or a redacted view of settings that hold secrets.
+ */
+interface WritableConfigResource extends ConfigResource
+{
+    /**
+     * Validate an incoming PUT body and turn it into a command.
+     *
+     * Implementations must not mutate anything: the returned command is
+     * dispatched by the caller, so validation failures surface as a 400 before
+     * any write happens.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws \App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand
+     */
+    public function buildUpdateCommand(array $payload): Command;
+}

--- a/src/Domain/Settings/UpdateAthleteFtpHistory/UpdateAthleteFtpHistory.php
+++ b/src/Domain/Settings/UpdateAthleteFtpHistory/UpdateAthleteFtpHistory.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteFtpHistory;
+
+use App\Domain\Ftp\FtpHistory;
+use App\Domain\Ftp\FtpSport;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\DeserializableCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\ProvidesCommandName;
+use App\Infrastructure\CQRS\Command\DomainCommand;
+use App\Infrastructure\CQRS\Command\RequiresRebuild;
+
+/**
+ * Replaces the athlete's FTP history for a single sport.
+ *
+ * Scoped per sport so that updating cycling cannot wipe running, and vice versa.
+ * FTP feeds derived metrics (w/kg, stress level), hence #[RequiresRebuild].
+ */
+#[RequiresRebuild]
+final readonly class UpdateAthleteFtpHistory extends DomainCommand implements DeserializableCommand
+{
+    use ProvidesCommandName;
+
+    /**
+     * @param list<array{on: string, ftp: int}> $entries
+     */
+    private function __construct(
+        private FtpSport $sport,
+        private array $entries,
+    ) {
+    }
+
+    public static function fromPayload(array $payload): self
+    {
+        $sport = is_string($payload['sport'] ?? null) ? FtpSport::tryFrom($payload['sport']) : null;
+        if (null === $sport) {
+            throw CouldNotDeserializeCommand::invalidPayload(sprintf('A valid "sport" is required, one of: %s.', implode(', ', array_column(FtpSport::cases(), 'value'))));
+        }
+
+        $entries = $payload['entries'] ?? null;
+        if (!is_array($entries)) {
+            throw CouldNotDeserializeCommand::invalidPayload('"entries" must be an array.');
+        }
+
+        $normalized = [];
+        foreach (array_values($entries) as $index => $entry) {
+            if (!is_array($entry)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('Entry #%d must be an object.', $index));
+            }
+
+            $on = $entry['on'] ?? null;
+            if (!is_string($on) || '' === trim($on)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('Entry #%d is missing a valid "on" date.', $index));
+            }
+
+            $ftp = $entry['ftp'] ?? null;
+            // FtpHistory casts with (int), which would silently turn "abc" into 0.
+            // Reject non-numeric input outright so the client gets a useful error.
+            if (!is_numeric($ftp)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('Entry #%d is missing a valid numeric "ftp".', $index));
+            }
+
+            $normalized[] = [
+                'on' => $on,
+                'ftp' => (int) $ftp,
+            ];
+        }
+
+        try {
+            // Always pass an explicitly keyed array. FtpHistory::fromArray() treats
+            // an array with neither sport key as a legacy cycling-only history, and
+            // we do not want to trip that BC shim by accident.
+            FtpHistory::fromArray([$sport->value => $normalized]);
+        } catch (\InvalidArgumentException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        return new self(
+            sport: $sport,
+            entries: $normalized
+        );
+    }
+
+    public function getSport(): FtpSport
+    {
+        return $this->sport;
+    }
+
+    /**
+     * @return list<array{on: string, ftp: int}>
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteFtpHistory/UpdateAthleteFtpHistoryCommandHandler.php
+++ b/src/Domain/Settings/UpdateAthleteFtpHistory/UpdateAthleteFtpHistoryCommandHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteFtpHistory;
+
+use App\Domain\Ftp\FtpSport;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Infrastructure\CQRS\Command\Command;
+use App\Infrastructure\CQRS\Command\CommandHandler;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class UpdateAthleteFtpHistoryCommandHandler implements CommandHandler
+{
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    public function handle(Command $command): void
+    {
+        assert($command instanceof UpdateAthleteFtpHistory);
+
+        $data = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        /** @var array<string, mixed> $athlete */
+        $athlete = is_array($data['athlete'] ?? null) ? $data['athlete'] : [];
+
+        $ftpHistory = $this->normalizeExistingHistory(is_array($athlete['ftpHistory'] ?? null) ? $athlete['ftpHistory'] : []);
+        // Replace only the requested sport, leaving the other one untouched.
+        $ftpHistory[$command->getSport()->value] = $command->getEntries();
+
+        $athlete['ftpHistory'] = $ftpHistory;
+        $data['athlete'] = $athlete;
+
+        $this->settingsRepository->save(
+            group: SettingsGroup::GENERAL,
+            data: $data,
+        );
+    }
+
+    /**
+     * A history predating the cycling/running split is a bare list of entries.
+     * FtpHistory reads that as cycling, so migrate it to the keyed shape before
+     * writing, otherwise the legacy entries would sit alongside the new key and
+     * be silently dropped on the next read.
+     *
+     * @param array<int|string, mixed> $ftpHistory
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeExistingHistory(array $ftpHistory): array
+    {
+        foreach (FtpSport::cases() as $sport) {
+            if (array_key_exists($sport->value, $ftpHistory)) {
+                /* @var array<string, mixed> $ftpHistory */
+                return $ftpHistory;
+            }
+        }
+
+        if ([] === $ftpHistory) {
+            return [];
+        }
+
+        return [FtpSport::CYCLING->value => array_values($ftpHistory)];
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteMaxHeartRate/UpdateAthleteMaxHeartRate.php
+++ b/src/Domain/Settings/UpdateAthleteMaxHeartRate/UpdateAthleteMaxHeartRate.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteMaxHeartRate;
+
+use App\Domain\Athlete\MaxHeartRate\MaxHeartRateFormulas;
+use App\Domain\Settings\AthleteSettingsPayload;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\DeserializableCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\ProvidesCommandName;
+use App\Infrastructure\CQRS\Command\DomainCommand;
+use App\Infrastructure\CQRS\Command\RequiresRebuild;
+
+/**
+ * Sets how the athlete's max heart rate is determined, either a named formula
+ * or measured values that apply from a given date onwards.
+ *
+ * Max heart rate drives the heart rate zones every activity is scored against,
+ * hence #[RequiresRebuild].
+ */
+#[RequiresRebuild]
+final readonly class UpdateAthleteMaxHeartRate extends DomainCommand implements DeserializableCommand
+{
+    use ProvidesCommandName;
+    public const string TYPE_FORMULA = 'formula';
+    public const string TYPE_MEASURED = 'measured';
+
+    /**
+     * @param string|array<string, int> $formula a named formula, or a date => bpm map
+     */
+    private function __construct(
+        private string|array $formula,
+    ) {
+    }
+
+    public static function fromPayload(array $payload): self
+    {
+        $type = $payload['type'] ?? null;
+        if (self::TYPE_FORMULA !== $type && self::TYPE_MEASURED !== $type) {
+            throw CouldNotDeserializeCommand::invalidPayload(sprintf('A valid "type" is required, one of: %s, %s.', self::TYPE_FORMULA, self::TYPE_MEASURED));
+        }
+
+        $formula = self::TYPE_FORMULA === $type
+            ? self::namedFormulaFromPayload($payload)
+            : self::measuredValuesFromPayload($payload);
+
+        try {
+            // Validate by construction, exactly as the settings form does.
+            new MaxHeartRateFormulas()->determineFormula($formula);
+        } catch (\RuntimeException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        return new self(
+            formula: $formula
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function namedFormulaFromPayload(array $payload): string
+    {
+        $formula = $payload['formula'] ?? null;
+        if (!is_string($formula) || '' === trim($formula)) {
+            throw CouldNotDeserializeCommand::invalidPayload('"formula" is required when type is "formula".');
+        }
+
+        return trim($formula);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, int>
+     */
+    private static function measuredValuesFromPayload(array $payload): array
+    {
+        $entries = $payload['entries'] ?? null;
+        if (!is_array($entries) || [] === $entries) {
+            throw CouldNotDeserializeCommand::invalidPayload('A non-empty "entries" array is required when type is "measured".');
+        }
+
+        try {
+            // Reuse the settings form's normalizer, so the API and the admin
+            // panel agree on shape, coercion and duplicate-date handling.
+            $normalized = AthleteSettingsPayload::normalize([
+                'maxHeartRateFormula' => 'dateRangeBased',
+                'maxHeartRateFormulaRanges' => array_values($entries),
+            ]);
+        } catch (\RuntimeException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        /** @var array<string, int> $ranges */
+        $ranges = $normalized['maxHeartRateFormula'];
+
+        return $ranges;
+    }
+
+    /**
+     * @return string|array<string, int>
+     */
+    public function getFormula(): string|array
+    {
+        return $this->formula;
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteMaxHeartRate/UpdateAthleteMaxHeartRateCommandHandler.php
+++ b/src/Domain/Settings/UpdateAthleteMaxHeartRate/UpdateAthleteMaxHeartRateCommandHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteMaxHeartRate;
+
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Infrastructure\CQRS\Command\Command;
+use App\Infrastructure\CQRS\Command\CommandHandler;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class UpdateAthleteMaxHeartRateCommandHandler implements CommandHandler
+{
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    public function handle(Command $command): void
+    {
+        assert($command instanceof UpdateAthleteMaxHeartRate);
+
+        $data = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        /** @var array<string, mixed> $athlete */
+        $athlete = is_array($data['athlete'] ?? null) ? $data['athlete'] : [];
+
+        $athlete['maxHeartRateFormula'] = $command->getFormula();
+        $data['athlete'] = $athlete;
+
+        $this->settingsRepository->save(
+            group: SettingsGroup::GENERAL,
+            data: $data,
+        );
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteRestingHeartRate/UpdateAthleteRestingHeartRate.php
+++ b/src/Domain/Settings/UpdateAthleteRestingHeartRate/UpdateAthleteRestingHeartRate.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteRestingHeartRate;
+
+use App\Domain\Athlete\RestingHeartRate\RestingHeartRateFormulas;
+use App\Domain\Settings\AthleteSettingsPayload;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\DeserializableCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\ProvidesCommandName;
+use App\Infrastructure\CQRS\Command\DomainCommand;
+use App\Infrastructure\CQRS\Command\RequiresRebuild;
+
+/**
+ * Sets how the athlete's resting heart rate is determined: the age-based
+ * heuristic, one fixed value, or measured values applying from a given date.
+ *
+ * Resting heart rate feeds heart rate reserve calculations, hence
+ * #[RequiresRebuild].
+ */
+#[RequiresRebuild]
+final readonly class UpdateAthleteRestingHeartRate extends DomainCommand implements DeserializableCommand
+{
+    use ProvidesCommandName;
+    public const string TYPE_FORMULA = 'formula';
+    public const string TYPE_FIXED = 'fixed';
+    public const string TYPE_MEASURED = 'measured';
+
+    /**
+     * @param string|int|array<string, int> $formula a named formula, a fixed bpm, or a date => bpm map
+     */
+    private function __construct(
+        private string|int|array $formula,
+    ) {
+    }
+
+    public static function fromPayload(array $payload): self
+    {
+        $type = $payload['type'] ?? null;
+
+        $formula = match ($type) {
+            self::TYPE_FORMULA => self::namedFormulaFromPayload($payload),
+            self::TYPE_FIXED => self::fixedValueFromPayload($payload),
+            self::TYPE_MEASURED => self::measuredValuesFromPayload($payload),
+            default => throw CouldNotDeserializeCommand::invalidPayload(sprintf('A valid "type" is required, one of: %s, %s, %s.', self::TYPE_FORMULA, self::TYPE_FIXED, self::TYPE_MEASURED)),
+        };
+
+        try {
+            // Validate by construction, exactly as the settings form does.
+            new RestingHeartRateFormulas()->determineFormula($formula);
+        } catch (\RuntimeException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        return new self(
+            formula: $formula
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function namedFormulaFromPayload(array $payload): string
+    {
+        $formula = $payload['formula'] ?? null;
+        if (!is_string($formula) || '' === trim($formula)) {
+            throw CouldNotDeserializeCommand::invalidPayload('"formula" is required when type is "formula".');
+        }
+
+        return trim($formula);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function fixedValueFromPayload(array $payload): int
+    {
+        try {
+            // Reuse the settings form's normalizer so the API and the admin
+            // panel agree on coercion and bounds.
+            $normalized = AthleteSettingsPayload::normalize([
+                'restingHeartRateFormula' => 'fixed',
+                'restingHeartRateFormulaFixedValue' => $payload['bpm'] ?? null,
+            ]);
+        } catch (\RuntimeException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        /** @var int $bpm */
+        $bpm = $normalized['restingHeartRateFormula'];
+
+        return $bpm;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, int>
+     */
+    private static function measuredValuesFromPayload(array $payload): array
+    {
+        $entries = $payload['entries'] ?? null;
+        if (!is_array($entries) || [] === $entries) {
+            throw CouldNotDeserializeCommand::invalidPayload('A non-empty "entries" array is required when type is "measured".');
+        }
+
+        try {
+            $normalized = AthleteSettingsPayload::normalize([
+                'restingHeartRateFormula' => 'dateRangeBased',
+                'restingHeartRateFormulaRanges' => array_values($entries),
+            ]);
+        } catch (\RuntimeException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        /** @var array<string, int> $ranges */
+        $ranges = $normalized['restingHeartRateFormula'];
+
+        return $ranges;
+    }
+
+    /**
+     * @return string|int|array<string, int>
+     */
+    public function getFormula(): string|int|array
+    {
+        return $this->formula;
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteRestingHeartRate/UpdateAthleteRestingHeartRateCommandHandler.php
+++ b/src/Domain/Settings/UpdateAthleteRestingHeartRate/UpdateAthleteRestingHeartRateCommandHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteRestingHeartRate;
+
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Infrastructure\CQRS\Command\Command;
+use App\Infrastructure\CQRS\Command\CommandHandler;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class UpdateAthleteRestingHeartRateCommandHandler implements CommandHandler
+{
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    public function handle(Command $command): void
+    {
+        assert($command instanceof UpdateAthleteRestingHeartRate);
+
+        $data = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        /** @var array<string, mixed> $athlete */
+        $athlete = is_array($data['athlete'] ?? null) ? $data['athlete'] : [];
+
+        $athlete['restingHeartRateFormula'] = $command->getFormula();
+        $data['athlete'] = $athlete;
+
+        $this->settingsRepository->save(
+            group: SettingsGroup::GENERAL,
+            data: $data,
+        );
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteWeightHistory/UpdateAthleteWeightHistory.php
+++ b/src/Domain/Settings/UpdateAthleteWeightHistory/UpdateAthleteWeightHistory.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteWeightHistory;
+
+use App\Domain\Athlete\Weight\AthleteWeightHistory;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\DeserializableCommand;
+use App\Infrastructure\CQRS\Command\Deserialize\ProvidesCommandName;
+use App\Infrastructure\CQRS\Command\DomainCommand;
+use App\Infrastructure\CQRS\Command\RequiresRebuild;
+use App\Infrastructure\ValueObject\Measurement\UnitSystem;
+
+/**
+ * Replaces the athlete's full weight history.
+ *
+ * Weight feeds derived metrics (w/kg, stress level), hence #[RequiresRebuild].
+ */
+#[RequiresRebuild]
+final readonly class UpdateAthleteWeightHistory extends DomainCommand implements DeserializableCommand
+{
+    use ProvidesCommandName;
+
+    /**
+     * @param list<array{on: string, weight: float}> $entries
+     */
+    private function __construct(
+        private array $entries,
+    ) {
+    }
+
+    public static function fromPayload(array $payload): self
+    {
+        $entries = $payload['entries'] ?? null;
+        if (!is_array($entries)) {
+            throw CouldNotDeserializeCommand::invalidPayload('"entries" must be an array.');
+        }
+
+        $normalized = [];
+        foreach (array_values($entries) as $index => $entry) {
+            if (!is_array($entry)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('Entry #%d must be an object.', $index));
+            }
+
+            $on = $entry['on'] ?? null;
+            if (!is_string($on) || '' === trim($on)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('Entry #%d is missing a valid "on" date.', $index));
+            }
+
+            $weight = $entry['weight'] ?? null;
+            if (!is_numeric($weight)) {
+                throw CouldNotDeserializeCommand::invalidPayload(sprintf('Entry #%d is missing a valid numeric "weight".', $index));
+            }
+
+            $normalized[] = [
+                'on' => $on,
+                'weight' => (float) $weight,
+            ];
+        }
+
+        try {
+            // GeneralSettings::fromArray() stores weightHistory verbatim without
+            // validating it, so an invalid entry would only blow up later at read
+            // time. Construct the history here to fail fast instead.
+            //
+            // The unit system only decides how the stored number is interpreted,
+            // never whether it is valid, so either one works for validation.
+            AthleteWeightHistory::fromArray($normalized, UnitSystem::METRIC);
+        } catch (\InvalidArgumentException $e) {
+            throw CouldNotDeserializeCommand::invalidPayload($e->getMessage());
+        }
+
+        return new self(
+            entries: $normalized
+        );
+    }
+
+    /**
+     * @return list<array{on: string, weight: float}>
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+}

--- a/src/Domain/Settings/UpdateAthleteWeightHistory/UpdateAthleteWeightHistoryCommandHandler.php
+++ b/src/Domain/Settings/UpdateAthleteWeightHistory/UpdateAthleteWeightHistoryCommandHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\UpdateAthleteWeightHistory;
+
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\SettingsRepository;
+use App\Infrastructure\CQRS\Command\Command;
+use App\Infrastructure\CQRS\Command\CommandHandler;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class UpdateAthleteWeightHistoryCommandHandler implements CommandHandler
+{
+    public function __construct(
+        #[Autowire(service: KeyValueBasedSettingsRepository::class)]
+        private SettingsRepository $settingsRepository,
+    ) {
+    }
+
+    public function handle(Command $command): void
+    {
+        assert($command instanceof UpdateAthleteWeightHistory);
+
+        $data = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        /** @var array<string, mixed> $athlete */
+        $athlete = is_array($data['athlete'] ?? null) ? $data['athlete'] : [];
+
+        // Only touch weightHistory, so an API client updating weight cannot
+        // clobber unrelated athlete settings.
+        $athlete['weightHistory'] = $command->getEntries();
+        $data['athlete'] = $athlete;
+
+        $this->settingsRepository->save(
+            group: SettingsGroup::GENERAL,
+            data: $data,
+        );
+    }
+}

--- a/src/Infrastructure/Config/ApiToken.php
+++ b/src/Infrastructure/Config/ApiToken.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Config;
+
+final readonly class ApiToken
+{
+    /**
+     * Anything shorter than this is trivially brute-forceable and is rejected at
+     * boot rather than silently accepted.
+     */
+    private const int MINIMUM_LENGTH = 32;
+
+    private function __construct(
+        private string $token,
+    ) {
+    }
+
+    public static function fromString(string $token): self
+    {
+        $token = trim($token);
+
+        if ('' !== $token && strlen($token) < self::MINIMUM_LENGTH) {
+            throw new \InvalidArgumentException(sprintf('API_TOKEN must be at least %d characters long.', self::MINIMUM_LENGTH));
+        }
+
+        return new self($token);
+    }
+
+    /**
+     * An empty token disables the API entirely. This is the default, so an
+     * installation that never opts in exposes no write surface.
+     */
+    public function isEnabled(): bool
+    {
+        return '' !== $this->token;
+    }
+
+    public function matches(string $candidate): bool
+    {
+        if (!$this->isEnabled()) {
+            return false;
+        }
+
+        return hash_equals($this->token, $candidate);
+    }
+}

--- a/src/Infrastructure/Http/Gate/AdminAllowedIpGate.php
+++ b/src/Infrastructure/Http/Gate/AdminAllowedIpGate.php
@@ -9,6 +9,10 @@ use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * Restricts the two ways of reaching configuration — the admin panel and the
+ * configuration API — to ADMIN_ALLOWED_IPS, so one setting covers both.
+ */
 #[AsTaggedItem(priority: 100)]
 final readonly class AdminAllowedIpGate implements Gate
 {
@@ -23,8 +27,7 @@ final readonly class AdminAllowedIpGate implements Gate
             return GateDecision::defer();
         }
 
-        $path = $request->getPathInfo();
-        if ('/admin' !== $path && !str_starts_with($path, '/admin/')) {
+        if (!$this->guardsPath($request->getPathInfo())) {
             return GateDecision::defer();
         }
 
@@ -35,5 +38,12 @@ final readonly class AdminAllowedIpGate implements Gate
         }
 
         throw new NotFoundHttpException('Not found');
+    }
+
+    private function guardsPath(string $path): bool
+    {
+        return '/admin' === $path
+            || str_starts_with($path, '/admin/')
+            || str_starts_with($path, self::API_PATH_PREFIX);
     }
 }

--- a/src/Infrastructure/Http/Gate/ConditionalRedirectGate.php
+++ b/src/Infrastructure/Http/Gate/ConditionalRedirectGate.php
@@ -31,9 +31,16 @@ abstract class ConditionalRedirectGate implements Gate
             return GateDecision::defer();
         }
 
-        $target = $this->urlGenerator->generate($this->redirectToRouteName());
-
         $path = $request->getPathInfo();
+
+        // A machine client needs a status code it can act on, not a 302 to a
+        // setup page it cannot render. Only redirects are skipped: gates that
+        // deny access, such as AdminAllowedIpGate, still apply to the API.
+        if (str_starts_with($path, self::API_PATH_PREFIX)) {
+            return GateDecision::defer();
+        }
+
+        $target = $this->urlGenerator->generate($this->redirectToRouteName());
         foreach ([...$this->allowedPaths(), $target] as $allowed) {
             if ($this->matches($path, $allowed)) {
                 return GateDecision::allow();

--- a/src/Infrastructure/Http/Gate/Gate.php
+++ b/src/Infrastructure/Http/Gate/Gate.php
@@ -10,5 +10,11 @@ use Symfony\Component\HttpFoundation\Request;
 #[AutoconfigureTag('app.http.gate')]
 interface Gate
 {
+    /**
+     * Requests under this prefix are served by the configuration API, which
+     * answers machine clients and must not be redirected into the setup flow.
+     */
+    public const string API_PATH_PREFIX = '/api/v1/';
+
     public function handle(Request $request): GateDecision;
 }

--- a/src/Infrastructure/Http/HttpStatusCode.php
+++ b/src/Infrastructure/Http/HttpStatusCode.php
@@ -9,6 +9,7 @@ enum HttpStatusCode: int
     case NOT_FOUND = 404;
     case UNAUTHORIZED = 401;
     case BAD_REQUEST = 400;
+    case METHOD_NOT_ALLOWED = 405;
     case INTERNAL_SERVER_ERROR = 500;
     case TOO_MANY_REQUESTS = 429;
 }

--- a/src/Infrastructure/Security/ApiTokenAuthenticator.php
+++ b/src/Infrastructure/Security/ApiTokenAuthenticator.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security;
+
+use App\Infrastructure\Config\ApiToken;
+use App\Infrastructure\Http\HttpStatusCode;
+use App\Infrastructure\Http\JsonErrorResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+final class ApiTokenAuthenticator extends AbstractAuthenticator
+{
+    public const string ROLE = 'ROLE_API';
+    private const string USER_IDENTIFIER = 'api';
+
+    public function __construct(
+        private readonly ApiToken $apiToken,
+    ) {
+    }
+
+    #[\Override]
+    public function supports(Request $request): bool
+    {
+        // The firewall pattern already scopes this authenticator to the API.
+        return true;
+    }
+
+    #[\Override]
+    public function authenticate(Request $request): SelfValidatingPassport
+    {
+        if (!$this->apiToken->isEnabled()) {
+            throw new CustomUserMessageAuthenticationException('The API is disabled. Set API_TOKEN to enable it.');
+        }
+
+        if (null === $token = $this->extractToken($request)) {
+            throw new CustomUserMessageAuthenticationException('Missing or malformed Authorization header, expected "Authorization: Bearer <token>".');
+        }
+
+        if (!$this->apiToken->matches($token)) {
+            throw new CustomUserMessageAuthenticationException('Invalid API token.');
+        }
+
+        return new SelfValidatingPassport(
+            new UserBadge(
+                self::USER_IDENTIFIER,
+                fn (string $identifier): InMemoryUser => new InMemoryUser($identifier, null, [self::ROLE]),
+            )
+        );
+    }
+
+    private function extractToken(Request $request): ?string
+    {
+        $header = $request->headers->get('Authorization');
+        if (!is_string($header)) {
+            return null;
+        }
+
+        if (1 !== preg_match('/^Bearer\s+(?<token>\S+)$/i', $header, $matches)) {
+            return null;
+        }
+
+        return $matches['token'];
+    }
+
+    #[\Override]
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    #[\Override]
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): JsonErrorResponse
+    {
+        return new JsonErrorResponse(
+            ['message' => $exception->getMessage()],
+            HttpStatusCode::UNAUTHORIZED->value,
+        );
+    }
+}

--- a/tests/Controller/Api/ConfigApiRequestHandlerTest.php
+++ b/tests/Controller/Api/ConfigApiRequestHandlerTest.php
@@ -1,0 +1,615 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller\Api;
+
+use App\Controller\Api\ConfigApiRequestHandler;
+use App\Domain\Settings\Api\ConfigResourceRegistry;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Infrastructure\CQRS\Command\Bus\CommandBus;
+use App\Infrastructure\KeyValue\KeyValue;
+use App\Infrastructure\KeyValue\KeyValueStore;
+use App\Infrastructure\KeyValue\Value;
+use App\Infrastructure\Serialization\Json;
+use App\Tests\ProvideSettings;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ConfigApiRequestHandlerTest extends WebTestCase
+{
+    use ProvideSettings;
+
+    private const string API_TOKEN = 'a-token-that-is-long-enough-to-be-accepted';
+
+    private KernelBrowser $client;
+    /** @var list<string> */
+    private array $overriddenEnv = [];
+
+    public function testItRejectsRequestsWithoutAToken(): void
+    {
+        $this->client->request('GET', '/api/v1/config');
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertSame(
+            'Missing or malformed Authorization header, expected "Authorization: Bearer <token>".',
+            $this->responseBody()['message']
+        );
+    }
+
+    public function testItRejectsAnInvalidToken(): void
+    {
+        $this->request('GET', '/api/v1/config', token: 'not-the-configured-token-but-long-enough');
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertSame('Invalid API token.', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsEveryTokenWhenTheApiIsDisabled(): void
+    {
+        $this->rebootWithApiToken('');
+        $this->request('GET', '/api/v1/config');
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertSame('The API is disabled. Set API_TOKEN to enable it.', $this->responseBody()['message']);
+    }
+
+    /**
+     * The API is exempt from the setup-flow gates in GateRequestListener, so
+     * clients get JSON instead of a 302 to a setup page. These two tests pin down
+     * that the exemption covers redirects only and does not weaken auth.
+     *
+     * This test case never marks the app as built, so the gates are live: proven
+     * by the sibling test below, where a non-API path does get redirected.
+     */
+    public function testItServesTheApiEvenWhenTheAppIsNotBuilt(): void
+    {
+        $this->request('GET', '/api/v1/config');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testANonApiPathIsStillRedirectedByTheGates(): void
+    {
+        $this->client->request('GET', '/');
+
+        $this->assertResponseRedirects();
+    }
+
+    public function testBypassingTheGatesDoesNotBypassAuthentication(): void
+    {
+        $this->client->request('GET', '/api/v1/config/athlete/weight-history');
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertFalse($this->client->getResponse()->isRedirection());
+    }
+
+    public function testTheAdminIpAllowListAlsoRestrictsTheApi(): void
+    {
+        // ADMIN_ALLOWED_IPS guards both routes into configuration. The test
+        // client reports 127.0.0.1, which is not on this list.
+        $this->rebootWithEnv(['ADMIN_ALLOWED_IPS' => '192.168.1.1']);
+        $this->request('GET', '/api/v1/config');
+
+        // 404 rather than 403, matching how the gate conceals the admin panel.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testItServesTheApiWhenTheClientIpIsAllowed(): void
+    {
+        $this->rebootWithEnv(['ADMIN_ALLOWED_IPS' => '127.0.0.1']);
+        $this->request('GET', '/api/v1/config');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testItListsTheAvailableResources(): void
+    {
+        $this->request('GET', '/api/v1/config');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([
+            'resources' => [
+                ['name' => 'athlete/ftp-history/cycling', 'href' => '/api/v1/config/athlete/ftp-history/cycling', 'methods' => ['GET', 'PUT']],
+                ['name' => 'athlete/ftp-history/running', 'href' => '/api/v1/config/athlete/ftp-history/running', 'methods' => ['GET', 'PUT']],
+                ['name' => 'athlete/max-heart-rate', 'href' => '/api/v1/config/athlete/max-heart-rate', 'methods' => ['GET', 'PUT']],
+                ['name' => 'athlete/resting-heart-rate', 'href' => '/api/v1/config/athlete/resting-heart-rate', 'methods' => ['GET', 'PUT']],
+                ['name' => 'athlete/weight-history', 'href' => '/api/v1/config/athlete/weight-history', 'methods' => ['GET', 'PUT']],
+                ['name' => 'zwift', 'href' => '/api/v1/config/zwift', 'methods' => ['GET', 'PUT']],
+            ],
+        ], $this->responseBody());
+    }
+
+    public function testItReturns404ForAnUnknownResource(): void
+    {
+        $this->request('GET', '/api/v1/config/athlete/shoe-size');
+
+        $this->assertResponseStatusCodeSame(404);
+        $this->assertSame('Configuration resource "athlete/shoe-size" does not exist.', $this->responseBody()['message']);
+    }
+
+    public function testItReturns404WhenPuttingToAnUnknownResource(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/shoe-size', ['entries' => []]);
+
+        $this->assertResponseStatusCodeSame(404);
+        $this->assertSame('Configuration resource "athlete/shoe-size" does not exist.', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsANonBearerAuthorizationHeader(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/v1/config',
+            server: ['HTTP_AUTHORIZATION' => 'Basic '.base64_encode('admin:password')]
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertStringContainsString('expected "Authorization: Bearer', $this->responseBody()['message']);
+    }
+
+    public function testItReadsALegacyUnkeyedFtpHistoryAsCycling(): void
+    {
+        // Pre-split histories are a bare list, which FtpHistory reads as
+        // cycling. GET must mirror that, and running must come back empty.
+        $this->provideLegacyFtpHistory([['on' => '2020-01-01', 'ftp' => 200]]);
+
+        $this->request('GET', '/api/v1/config/athlete/ftp-history/cycling');
+        $this->assertSame([
+            'sport' => 'cycling',
+            'entries' => [['on' => '2020-01-01', 'ftp' => 200]],
+        ], $this->responseBody());
+
+        $this->request('GET', '/api/v1/config/athlete/ftp-history/running');
+        $this->assertSame(['sport' => 'running', 'entries' => []], $this->responseBody());
+    }
+
+    public function testItReadsTheWeightHistory(): void
+    {
+        $this->request('GET', '/api/v1/config/athlete/weight-history');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([
+            'unit' => 'kg',
+            'entries' => [
+                ['on' => '2020-01-01', 'weight' => 68],
+                ['on' => '2019-12-01', 'weight' => 69],
+                ['on' => '2019-08-01', 'weight' => 70],
+                ['on' => '2019-07-01', 'weight' => 71],
+            ],
+        ], $this->responseBody());
+    }
+
+    public function testItUpdatesTheWeightHistoryAndEchoesTheStoredState(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', [
+            'entries' => [
+                ['on' => '2024-01-01', 'weight' => 70.5],
+                ['on' => '2024-06-01', 'weight' => '69'],
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        // assertEquals, not assertSame: a whole-number float round-trips through
+        // JSON as an int, so 69.0 comes back as 69.
+        $this->assertEquals([
+            'unit' => 'kg',
+            'entries' => [
+                ['on' => '2024-01-01', 'weight' => 70.5],
+                ['on' => '2024-06-01', 'weight' => 69.0],
+            ],
+        ], $this->responseBody());
+
+        $this->assertEquals(
+            [['on' => '2024-01-01', 'weight' => 70.5], ['on' => '2024-06-01', 'weight' => 69.0]],
+            $this->athleteSettings()['weightHistory']
+        );
+    }
+
+    public function testItLeavesOtherAthleteSettingsAloneWhenUpdatingWeight(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', [
+            'entries' => [['on' => '2024-01-01', 'weight' => 70.5]],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $athlete = $this->athleteSettings();
+        $this->assertSame('1989-08-14', $athlete['birthday']);
+        $this->assertSame('Robin', $athlete['firstName']);
+        $this->assertArrayHasKey('ftpHistory', $athlete);
+    }
+
+    public function testItRejectsANonNumericWeight(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', [
+            'entries' => [['on' => '2024-01-01', 'weight' => 'heavy']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertSame('Entry #0 is missing a valid numeric "weight".', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsAnInvalidDate(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', [
+            'entries' => [['on' => 'the-first-of-never', 'weight' => 70]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('Invalid date', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsAUnitThatDoesNotMatchTheConfiguredUnitSystem(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', [
+            'unit' => 'lb',
+            'entries' => [['on' => '2024-01-01', 'weight' => 155]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('Weights are stored in "kg"', $this->responseBody()['message']);
+    }
+
+    public function testItAcceptsAMatchingUnit(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', [
+            'unit' => 'kg',
+            'entries' => [['on' => '2024-01-01', 'weight' => 70]],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testItRejectsAMalformedBody(): void
+    {
+        $this->client->request(
+            'PUT',
+            '/api/v1/config/athlete/weight-history',
+            server: $this->authHeaders(self::API_TOKEN),
+            content: '{not json'
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testItRejectsANonObjectBody(): void
+    {
+        $this->client->request(
+            'PUT',
+            '/api/v1/config/athlete/weight-history',
+            server: $this->authHeaders(self::API_TOKEN),
+            content: '"a string"'
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertSame('Request body must be a JSON object.', $this->responseBody()['message']);
+    }
+
+    public function testItReadsTheCyclingFtpHistory(): void
+    {
+        $this->request('GET', '/api/v1/config/athlete/ftp-history/cycling');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([
+            'sport' => 'cycling',
+            'entries' => [
+                ['on' => '2023-01-01', 'ftp' => 198],
+                ['on' => '2023-03-22', 'ftp' => 220],
+                ['on' => '2023-03-29', 'ftp' => 238],
+                ['on' => '2023-04-01', 'ftp' => 250],
+            ],
+        ], $this->responseBody());
+    }
+
+    public function testUpdatingOneSportDoesNotClobberTheOther(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/ftp-history/cycling', [
+            'entries' => [['on' => '2025-01-01', 'ftp' => 300]],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $ftpHistory = $this->athleteSettings()['ftpHistory'];
+        $this->assertSame([['on' => '2025-01-01', 'ftp' => 300]], $ftpHistory['cycling']);
+        $this->assertCount(4, $ftpHistory['running']);
+    }
+
+    public function testItIgnoresASportInTheBodyAndUsesTheOneFromTheUrl(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/ftp-history/running', [
+            'sport' => 'cycling',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 150]],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $ftpHistory = $this->athleteSettings()['ftpHistory'];
+        $this->assertSame([['on' => '2025-01-01', 'ftp' => 150]], $ftpHistory['running']);
+        $this->assertCount(4, $ftpHistory['cycling']);
+    }
+
+    public function testItRejectsANonNumericFtp(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/ftp-history/cycling', [
+            'entries' => [['on' => '2025-01-01', 'ftp' => 'strong']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertSame('Entry #0 is missing a valid numeric "ftp".', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsAnFtpBelowOne(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/ftp-history/cycling', [
+            'entries' => [['on' => '2025-01-01', 'ftp' => 0]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('Minimum FTP of 1 expected', $this->responseBody()['message']);
+    }
+
+    public function testItAcceptsAnEmptyHistory(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/ftp-history/cycling', ['entries' => []]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([], $this->athleteSettings()['ftpHistory']['cycling']);
+    }
+
+    public function testItRejectsEntriesThatAreNotAnArray(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/weight-history', ['entries' => 'nope']);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertSame('"entries" must be an array.', $this->responseBody()['message']);
+    }
+
+    public function testAReadOnlyResourceAdvertisesGetOnlyAndRefusesPut(): void
+    {
+        $handler = new ConfigApiRequestHandler(
+            new ConfigResourceRegistry([new StubReadOnlyConfigResource()]),
+            $this->getContainer()->get(CommandBus::class),
+            $this->getContainer()->get(UrlGeneratorInterface::class),
+        );
+
+        $index = Json::decode((string) $handler->index()->getContent());
+        $this->assertSame(['GET'], $index['resources'][0]['methods']);
+
+        $response = $handler->update(
+            'stub/read-only',
+            Request::create('/api/v1/config/stub/read-only', 'PUT', content: '{}')
+        );
+
+        $this->assertSame(405, $response->getStatusCode());
+        $this->assertSame('GET', $response->headers->get('Allow'));
+        $this->assertSame(
+            'Configuration resource "stub/read-only" is read-only.',
+            Json::decode((string) $response->getContent())['message']
+        );
+    }
+
+    public function testItReadsAMaxHeartRateNamedFormula(): void
+    {
+        $this->request('GET', '/api/v1/config/athlete/max-heart-rate');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(['type' => 'formula', 'formula' => 'fox'], $this->responseBody());
+    }
+
+    public function testItSwitchesMaxHeartRateToMeasuredValues(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/max-heart-rate', [
+            'type' => 'measured',
+            'entries' => [
+                ['on' => '2020-01-01', 'bpm' => 198],
+                ['on' => '2025-01-10', 'bpm' => 193],
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([
+            'type' => 'measured',
+            'entries' => [
+                ['on' => '2020-01-01', 'bpm' => 198],
+                ['on' => '2025-01-10', 'bpm' => 193],
+            ],
+        ], $this->responseBody());
+        // Stored in the app's own date => bpm shape, not the API's list shape.
+        $this->assertSame(['2020-01-01' => 198, '2025-01-10' => 193], $this->athleteSettings()['maxHeartRateFormula']);
+    }
+
+    public function testItRejectsAnUnknownMaxHeartRateFormula(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/max-heart-rate', ['type' => 'formula', 'formula' => 'guesswork']);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('Invalid MAX_HEART_RATE_FORMULA', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsADuplicateDateInMeasuredHeartRates(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/max-heart-rate', [
+            'type' => 'measured',
+            'entries' => [['on' => '2020-01-01', 'bpm' => 198], ['on' => '2020-01-01', 'bpm' => 190]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('cannot contain the same date more than once', $this->responseBody()['message']);
+    }
+
+    public function testItRejectsAnUnknownHeartRateType(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/max-heart-rate', ['type' => 'vibes']);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('A valid "type" is required', $this->responseBody()['message']);
+    }
+
+    public function testItDefaultsRestingHeartRateToTheAgeBasedHeuristic(): void
+    {
+        $this->request('GET', '/api/v1/config/athlete/resting-heart-rate');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(['type' => 'formula', 'formula' => 'heuristicAgeBased'], $this->responseBody());
+    }
+
+    public function testItSetsAFixedRestingHeartRate(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/resting-heart-rate', ['type' => 'fixed', 'bpm' => 52]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(['type' => 'fixed', 'bpm' => 52], $this->responseBody());
+        $this->assertSame(52, $this->athleteSettings()['restingHeartRateFormula']);
+    }
+
+    public function testItSetsMeasuredRestingHeartRates(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/resting-heart-rate', [
+            'type' => 'measured',
+            'entries' => [['on' => '2024-01-01', 'bpm' => 54]],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([
+            'type' => 'measured',
+            'entries' => [['on' => '2024-01-01', 'bpm' => 54]],
+        ], $this->responseBody());
+    }
+
+    public function testItRejectsANonPositiveRestingHeartRate(): void
+    {
+        $this->request('PUT', '/api/v1/config/athlete/resting-heart-rate', ['type' => 'fixed', 'bpm' => 0]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertStringContainsString('greater than zero', $this->responseBody()['message']);
+    }
+
+    public function testItReadsAndUpdatesZwiftSettings(): void
+    {
+        $this->request('GET', '/api/v1/config/zwift');
+        $this->assertSame(['level' => 80, 'racingScore' => 495], $this->responseBody());
+
+        $this->request('PUT', '/api/v1/config/zwift', ['level' => 42, 'racingScore' => null]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(['level' => 42, 'racingScore' => null], $this->responseBody());
+    }
+
+    public function testItRejectsANonNumericZwiftLevel(): void
+    {
+        $this->request('PUT', '/api/v1/config/zwift', ['level' => 'expert']);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertSame('"level" must be a number or null.', $this->responseBody()['message']);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function request(string $method, string $uri, array $payload = [], string $token = self::API_TOKEN): void
+    {
+        $this->client->request(
+            $method,
+            $uri,
+            server: $this->authHeaders($token),
+            content: 'GET' === $method ? null : Json::encode($payload)
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function authHeaders(string $token): array
+    {
+        return [
+            'HTTP_AUTHORIZATION' => 'Bearer '.$token,
+            'CONTENT_TYPE' => 'application/json',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function responseBody(): array
+    {
+        return Json::decode((string) $this->client->getResponse()->getContent());
+    }
+
+    /**
+     * @param list<array{on: string, ftp: int}> $entries
+     */
+    private function provideLegacyFtpHistory(array $entries): void
+    {
+        /** @var KeyValueStore $keyValueStore */
+        $keyValueStore = $this->getContainer()->get(KeyValueStore::class);
+
+        /** @var KeyValueBasedSettingsRepository $settingsRepository */
+        $settingsRepository = $this->getContainer()->get(KeyValueBasedSettingsRepository::class);
+        $general = $settingsRepository->find(SettingsGroup::GENERAL);
+        $general['athlete']['ftpHistory'] = $entries;
+
+        $keyValueStore->save(KeyValue::fromState(
+            SettingsGroup::GENERAL->keyValueKey(),
+            Value::fromString(Json::encode($general)),
+        ));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function athleteSettings(): array
+    {
+        // Uncached on purpose, so assertions reflect what is actually persisted
+        // rather than a memoized CachingSettingsRepository entry.
+        /** @var KeyValueBasedSettingsRepository $settingsRepository */
+        $settingsRepository = $this->getContainer()->get(KeyValueBasedSettingsRepository::class);
+
+        return $settingsRepository->find(SettingsGroup::GENERAL)['athlete'];
+    }
+
+    private function rebootWithApiToken(string $token): void
+    {
+        $this->rebootWithEnv(['API_TOKEN' => $token]);
+    }
+
+    /**
+     * @param array<string, string> $env
+     */
+    private function rebootWithEnv(array $env): void
+    {
+        self::ensureKernelShutdown();
+        foreach ($env as $name => $value) {
+            $_SERVER[$name] = $_ENV[$name] = $value;
+            $this->overriddenEnv[] = $name;
+        }
+        $this->client = static::createClient();
+        $this->client->disableReboot();
+        $this->provideSettings();
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_SERVER['API_TOKEN'] = $_ENV['API_TOKEN'] = self::API_TOKEN;
+
+        $this->client = static::createClient();
+        $this->client->disableReboot();
+        $this->provideSettings();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        foreach ([...$this->overriddenEnv, 'API_TOKEN'] as $name) {
+            unset($_SERVER[$name], $_ENV[$name]);
+        }
+        $this->overriddenEnv = [];
+
+        parent::tearDown();
+    }
+}

--- a/tests/Controller/Api/StubReadOnlyConfigResource.php
+++ b/tests/Controller/Api/StubReadOnlyConfigResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller\Api;
+
+use App\Domain\Settings\Api\ConfigResource;
+
+/**
+ * Every shipped resource is writable, so this stub exists to cover the
+ * read-only branch of the API: advertising GET only, and refusing PUT.
+ */
+final readonly class StubReadOnlyConfigResource implements ConfigResource
+{
+    #[\Override]
+    public function getName(): string
+    {
+        return 'stub/read-only';
+    }
+
+    #[\Override]
+    public function read(): array
+    {
+        return ['stub' => true];
+    }
+}

--- a/tests/Domain/Settings/Api/Resource/HeartRateRangesTest.php
+++ b/tests/Domain/Settings/Api/Resource/HeartRateRangesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Settings\Api\Resource;
+
+use App\Domain\Settings\Api\Resource\HeartRateRanges;
+use PHPUnit\Framework\TestCase;
+
+class HeartRateRangesTest extends TestCase
+{
+    public function testItConvertsADateMapToEntries(): void
+    {
+        $this->assertSame(
+            [['on' => '2020-01-01', 'bpm' => 198], ['on' => '2025-01-10', 'bpm' => 193]],
+            HeartRateRanges::toEntries(['2020-01-01' => 198, '2025-01-10' => 193])
+        );
+    }
+
+    public function testItCoercesNumericStrings(): void
+    {
+        $this->assertSame(
+            [['on' => '2020-01-01', 'bpm' => 198]],
+            HeartRateRanges::toEntries(['2020-01-01' => '198'])
+        );
+    }
+
+    public function testItSkipsNonNumericValues(): void
+    {
+        // Defensive: settings written before validation existed, or hand-edited
+        // in the database, should not break a read.
+        $this->assertSame(
+            [['on' => '2020-01-01', 'bpm' => 198]],
+            HeartRateRanges::toEntries(['2020-01-01' => 198, '2021-01-01' => 'nonsense'])
+        );
+    }
+
+    public function testItReturnsAnEmptyListForAnEmptyMap(): void
+    {
+        $this->assertSame([], HeartRateRanges::toEntries([]));
+    }
+}

--- a/tests/Domain/Settings/UpdateAthleteFtpHistory/UpdateAthleteFtpHistoryCommandHandlerTest.php
+++ b/tests/Domain/Settings/UpdateAthleteFtpHistory/UpdateAthleteFtpHistoryCommandHandlerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Settings\UpdateAthleteFtpHistory;
+
+use App\Domain\Ftp\FtpSport;
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\UpdateAthleteFtpHistory\UpdateAthleteFtpHistory;
+use App\Infrastructure\CQRS\Command\Bus\CommandBus;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Infrastructure\KeyValue\KeyValue;
+use App\Infrastructure\KeyValue\KeyValueStore;
+use App\Infrastructure\KeyValue\Value;
+use App\Infrastructure\Serialization\Json;
+use App\Tests\ContainerTestCase;
+
+class UpdateAthleteFtpHistoryCommandHandlerTest extends ContainerTestCase
+{
+    private CommandBus $commandBus;
+    // Uncached on purpose: the handler writes through this same repository,
+    // so a memoized find() would hide what was actually persisted.
+    private KeyValueBasedSettingsRepository $settingsRepository;
+
+    public function testHandle(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'cycling',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 300]],
+        ]));
+
+        $this->assertSame(
+            [['on' => '2025-01-01', 'ftp' => 300]],
+            $this->athlete()['ftpHistory'][FtpSport::CYCLING->value]
+        );
+    }
+
+    public function testItLeavesTheOtherSportUntouched(): void
+    {
+        $before = $this->athlete()['ftpHistory'][FtpSport::RUNNING->value];
+
+        $this->commandBus->dispatch(UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'cycling',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 300]],
+        ]));
+
+        $this->assertSame($before, $this->athlete()['ftpHistory'][FtpSport::RUNNING->value]);
+    }
+
+    public function testItMigratesALegacyUnkeyedHistoryToCycling(): void
+    {
+        $this->provideLegacyFtpHistory([
+            ['on' => '2020-01-01', 'ftp' => 200],
+            ['on' => '2021-01-01', 'ftp' => 210],
+        ]);
+
+        $this->commandBus->dispatch(UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'running',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 150]],
+        ]));
+
+        $ftpHistory = $this->athlete()['ftpHistory'];
+        // The legacy entries were cycling by convention, so they must survive
+        // under an explicit key rather than being dropped on the next read.
+        $this->assertSame(
+            [['on' => '2020-01-01', 'ftp' => 200], ['on' => '2021-01-01', 'ftp' => 210]],
+            $ftpHistory[FtpSport::CYCLING->value]
+        );
+        $this->assertSame([['on' => '2025-01-01', 'ftp' => 150]], $ftpHistory[FtpSport::RUNNING->value]);
+    }
+
+    public function testItPreservesUnrelatedAthleteSettings(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'running',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 150]],
+        ]));
+
+        $athlete = $this->athlete();
+        $this->assertSame('1989-08-14', $athlete['birthday']);
+        $this->assertCount(4, $athlete['weightHistory']);
+    }
+
+    public function testItAcceptsAnEmptyHistory(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'cycling',
+            'entries' => [],
+        ]));
+
+        $this->assertSame([], $this->athlete()['ftpHistory'][FtpSport::CYCLING->value]);
+    }
+
+    public function testItThrowsOnAnUnknownSport(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('A valid "sport" is required, one of: cycling, running.');
+
+        UpdateAthleteFtpHistory::fromPayload(['sport' => 'swimming', 'entries' => []]);
+    }
+
+    public function testItThrowsOnAMissingSport(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+
+        UpdateAthleteFtpHistory::fromPayload(['entries' => []]);
+    }
+
+    public function testItThrowsOnANonNumericFtp(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Entry #0 is missing a valid numeric "ftp".');
+
+        UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'cycling',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 'strong']],
+        ]);
+    }
+
+    public function testItThrowsOnAnFtpBelowOne(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Minimum FTP of 1 expected');
+
+        UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'cycling',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 0]],
+        ]);
+    }
+
+    public function testItThrowsWhenEntriesIsNotAnArray(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('"entries" must be an array.');
+
+        UpdateAthleteFtpHistory::fromPayload(['sport' => 'cycling', 'entries' => 'nope']);
+    }
+
+    public function testItThrowsOnANonObjectEntry(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Entry #0 must be an object.');
+
+        UpdateAthleteFtpHistory::fromPayload(['sport' => 'cycling', 'entries' => ['nope']]);
+    }
+
+    public function testItHandlesAnAbsentFtpHistory(): void
+    {
+        // No ftpHistory key at all: the legacy migration must not invent a
+        // bogus cycling entry out of an empty array.
+        $this->provideAthleteWithoutFtpHistory();
+
+        $this->commandBus->dispatch(UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'running',
+            'entries' => [['on' => '2025-01-01', 'ftp' => 150]],
+        ]));
+
+        $this->assertSame(
+            [FtpSport::RUNNING->value => [['on' => '2025-01-01', 'ftp' => 150]]],
+            $this->athlete()['ftpHistory']
+        );
+    }
+
+    public function testItThrowsOnAMissingDate(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Entry #0 is missing a valid "on" date.');
+
+        UpdateAthleteFtpHistory::fromPayload([
+            'sport' => 'cycling',
+            'entries' => [['ftp' => 250]],
+        ]);
+    }
+
+    private function provideAthleteWithoutFtpHistory(): void
+    {
+        /** @var KeyValueStore $keyValueStore */
+        $keyValueStore = $this->getContainer()->get(KeyValueStore::class);
+
+        $general = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        unset($general['athlete']['ftpHistory']);
+
+        $keyValueStore->save(KeyValue::fromState(
+            SettingsGroup::GENERAL->keyValueKey(),
+            Value::fromString(Json::encode($general)),
+        ));
+    }
+
+    /**
+     * @param list<array{on: string, ftp: int}> $entries
+     */
+    private function provideLegacyFtpHistory(array $entries): void
+    {
+        /** @var KeyValueStore $keyValueStore */
+        $keyValueStore = $this->getContainer()->get(KeyValueStore::class);
+
+        $general = $this->settingsRepository->find(SettingsGroup::GENERAL);
+        $general['athlete']['ftpHistory'] = $entries;
+
+        $keyValueStore->save(KeyValue::fromState(
+            SettingsGroup::GENERAL->keyValueKey(),
+            Value::fromString(Json::encode($general)),
+        ));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function athlete(): array
+    {
+        return $this->settingsRepository->find(SettingsGroup::GENERAL)['athlete'];
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commandBus = $this->getContainer()->get(CommandBus::class);
+        $this->settingsRepository = $this->getContainer()->get(KeyValueBasedSettingsRepository::class);
+    }
+}

--- a/tests/Domain/Settings/UpdateAthleteMaxHeartRate/UpdateAthleteMaxHeartRateCommandHandlerTest.php
+++ b/tests/Domain/Settings/UpdateAthleteMaxHeartRate/UpdateAthleteMaxHeartRateCommandHandlerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Settings\UpdateAthleteMaxHeartRate;
+
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\UpdateAthleteMaxHeartRate\UpdateAthleteMaxHeartRate;
+use App\Infrastructure\CQRS\Command\Bus\CommandBus;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Tests\ContainerTestCase;
+
+class UpdateAthleteMaxHeartRateCommandHandlerTest extends ContainerTestCase
+{
+    private CommandBus $commandBus;
+    private KeyValueBasedSettingsRepository $settingsRepository;
+
+    public function testHandleForANamedFormula(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteMaxHeartRate::fromPayload([
+            'type' => 'formula',
+            'formula' => 'tanaka',
+        ]));
+
+        $this->assertSame('tanaka', $this->athlete()['maxHeartRateFormula']);
+    }
+
+    public function testHandleForMeasuredValues(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteMaxHeartRate::fromPayload([
+            'type' => 'measured',
+            'entries' => [
+                ['on' => '2020-01-01', 'bpm' => 198],
+                ['on' => '2025-01-10', 'bpm' => 193],
+            ],
+        ]));
+
+        // Persisted in the app's date => bpm shape, which is what
+        // MaxHeartRateFormulas expects.
+        $this->assertSame(
+            ['2020-01-01' => 198, '2025-01-10' => 193],
+            $this->athlete()['maxHeartRateFormula']
+        );
+    }
+
+    public function testItPreservesUnrelatedAthleteSettings(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteMaxHeartRate::fromPayload([
+            'type' => 'formula',
+            'formula' => 'nes',
+        ]));
+
+        $athlete = $this->athlete();
+        $this->assertSame('1989-08-14', $athlete['birthday']);
+        $this->assertCount(4, $athlete['weightHistory']);
+    }
+
+    public function testItThrowsOnAnUnknownFormula(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Invalid MAX_HEART_RATE_FORMULA "guesswork" detected');
+
+        UpdateAthleteMaxHeartRate::fromPayload(['type' => 'formula', 'formula' => 'guesswork']);
+    }
+
+    public function testItThrowsOnAnUnknownType(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('A valid "type" is required, one of: formula, measured.');
+
+        UpdateAthleteMaxHeartRate::fromPayload(['type' => 'vibes']);
+    }
+
+    public function testItThrowsOnAMissingFormula(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('"formula" is required when type is "formula".');
+
+        UpdateAthleteMaxHeartRate::fromPayload(['type' => 'formula']);
+    }
+
+    public function testItThrowsOnEmptyMeasuredValues(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('A non-empty "entries" array is required when type is "measured".');
+
+        UpdateAthleteMaxHeartRate::fromPayload(['type' => 'measured', 'entries' => []]);
+    }
+
+    public function testItThrowsOnADuplicateDate(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('cannot contain the same date more than once');
+
+        UpdateAthleteMaxHeartRate::fromPayload(['type' => 'measured', 'entries' => [
+            ['on' => '2020-01-01', 'bpm' => 198],
+            ['on' => '2020-01-01', 'bpm' => 190],
+        ]]);
+    }
+
+    public function testItThrowsOnANonPositiveHeartRate(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('needs a heart rate greater than zero');
+
+        UpdateAthleteMaxHeartRate::fromPayload(['type' => 'measured', 'entries' => [
+            ['on' => '2020-01-01', 'bpm' => 0],
+        ]]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function athlete(): array
+    {
+        return $this->settingsRepository->find(SettingsGroup::GENERAL)['athlete'];
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commandBus = $this->getContainer()->get(CommandBus::class);
+        $this->settingsRepository = $this->getContainer()->get(KeyValueBasedSettingsRepository::class);
+    }
+}

--- a/tests/Domain/Settings/UpdateAthleteRestingHeartRate/UpdateAthleteRestingHeartRateCommandHandlerTest.php
+++ b/tests/Domain/Settings/UpdateAthleteRestingHeartRate/UpdateAthleteRestingHeartRateCommandHandlerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Settings\UpdateAthleteRestingHeartRate;
+
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\UpdateAthleteRestingHeartRate\UpdateAthleteRestingHeartRate;
+use App\Infrastructure\CQRS\Command\Bus\CommandBus;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Tests\ContainerTestCase;
+
+class UpdateAthleteRestingHeartRateCommandHandlerTest extends ContainerTestCase
+{
+    private CommandBus $commandBus;
+    private KeyValueBasedSettingsRepository $settingsRepository;
+
+    public function testHandleForTheAgeBasedHeuristic(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteRestingHeartRate::fromPayload([
+            'type' => 'formula',
+            'formula' => 'heuristicAgeBased',
+        ]));
+
+        $this->assertSame('heuristicAgeBased', $this->athlete()['restingHeartRateFormula']);
+    }
+
+    public function testHandleForAFixedValue(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteRestingHeartRate::fromPayload([
+            'type' => 'fixed',
+            'bpm' => 52,
+        ]));
+
+        $this->assertSame(52, $this->athlete()['restingHeartRateFormula']);
+    }
+
+    public function testHandleForMeasuredValues(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteRestingHeartRate::fromPayload([
+            'type' => 'measured',
+            'entries' => [
+                ['on' => '2024-01-01', 'bpm' => 54],
+                ['on' => '2025-01-01', 'bpm' => 50],
+            ],
+        ]));
+
+        $this->assertSame(
+            ['2024-01-01' => 54, '2025-01-01' => 50],
+            $this->athlete()['restingHeartRateFormula']
+        );
+    }
+
+    public function testItAcceptsANumericStringAsFixed(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteRestingHeartRate::fromPayload([
+            'type' => 'fixed',
+            'bpm' => '48',
+        ]));
+
+        $this->assertSame(48, $this->athlete()['restingHeartRateFormula']);
+    }
+
+    public function testItPreservesUnrelatedAthleteSettings(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteRestingHeartRate::fromPayload([
+            'type' => 'fixed',
+            'bpm' => 52,
+        ]));
+
+        $athlete = $this->athlete();
+        $this->assertSame('1989-08-14', $athlete['birthday']);
+        $this->assertSame('fox', $athlete['maxHeartRateFormula']);
+    }
+
+    public function testItThrowsOnAnUnknownFormula(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Invalid RESTING_HEART_RATE_FORMULA "guesswork" detected');
+
+        UpdateAthleteRestingHeartRate::fromPayload(['type' => 'formula', 'formula' => 'guesswork']);
+    }
+
+    public function testItThrowsOnAnUnknownType(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('A valid "type" is required, one of: formula, fixed, measured.');
+
+        UpdateAthleteRestingHeartRate::fromPayload([]);
+    }
+
+    public function testItThrowsOnANonPositiveFixedValue(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('needs a heart rate greater than zero');
+
+        UpdateAthleteRestingHeartRate::fromPayload(['type' => 'fixed', 'bpm' => 0]);
+    }
+
+    public function testItThrowsOnAFractionalFixedValue(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('needs a heart rate greater than zero');
+
+        UpdateAthleteRestingHeartRate::fromPayload(['type' => 'fixed', 'bpm' => 52.4]);
+    }
+
+    public function testItThrowsOnAMissingFormula(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('"formula" is required when type is "formula".');
+
+        UpdateAthleteRestingHeartRate::fromPayload(['type' => 'formula']);
+    }
+
+    public function testItThrowsOnEmptyMeasuredValues(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('A non-empty "entries" array is required when type is "measured".');
+
+        UpdateAthleteRestingHeartRate::fromPayload(['type' => 'measured', 'entries' => []]);
+    }
+
+    public function testItThrowsOnAMeasuredEntryWithoutADate(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('needs a date');
+
+        UpdateAthleteRestingHeartRate::fromPayload(['type' => 'measured', 'entries' => [['bpm' => 52]]]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function athlete(): array
+    {
+        return $this->settingsRepository->find(SettingsGroup::GENERAL)['athlete'];
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commandBus = $this->getContainer()->get(CommandBus::class);
+        $this->settingsRepository = $this->getContainer()->get(KeyValueBasedSettingsRepository::class);
+    }
+}

--- a/tests/Domain/Settings/UpdateAthleteWeightHistory/UpdateAthleteWeightHistoryCommandHandlerTest.php
+++ b/tests/Domain/Settings/UpdateAthleteWeightHistory/UpdateAthleteWeightHistoryCommandHandlerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\Settings\UpdateAthleteWeightHistory;
+
+use App\Domain\Settings\KeyValueBasedSettingsRepository;
+use App\Domain\Settings\SettingsGroup;
+use App\Domain\Settings\UpdateAthleteWeightHistory\UpdateAthleteWeightHistory;
+use App\Infrastructure\CQRS\Command\Bus\CommandBus;
+use App\Infrastructure\CQRS\Command\Deserialize\CouldNotDeserializeCommand;
+use App\Tests\ContainerTestCase;
+
+class UpdateAthleteWeightHistoryCommandHandlerTest extends ContainerTestCase
+{
+    private CommandBus $commandBus;
+    // Uncached on purpose: the handler writes through this same repository,
+    // so a memoized find() would hide what was actually persisted.
+    private KeyValueBasedSettingsRepository $settingsRepository;
+
+    public function testHandle(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteWeightHistory::fromPayload([
+            'entries' => [
+                ['on' => '2024-01-01', 'weight' => 70.5],
+                ['on' => '2024-06-01', 'weight' => 68],
+            ],
+        ]));
+
+        // assertEquals, not assertSame: a whole-number float round-trips through
+        // JSON as an int, so 68.0 comes back as 68.
+        $this->assertEquals(
+            [
+                ['on' => '2024-01-01', 'weight' => 70.5],
+                ['on' => '2024-06-01', 'weight' => 68.0],
+            ],
+            $this->athlete()['weightHistory']
+        );
+    }
+
+    public function testItReplacesRatherThanMergesTheHistory(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteWeightHistory::fromPayload([
+            'entries' => [['on' => '2024-01-01', 'weight' => 70.5]],
+        ]));
+
+        $this->assertCount(1, $this->athlete()['weightHistory']);
+    }
+
+    public function testItPreservesUnrelatedAthleteSettings(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteWeightHistory::fromPayload([
+            'entries' => [['on' => '2024-01-01', 'weight' => 70.5]],
+        ]));
+
+        $athlete = $this->athlete();
+        $this->assertSame('1989-08-14', $athlete['birthday']);
+        $this->assertSame('fox', $athlete['maxHeartRateFormula']);
+        $this->assertCount(4, $athlete['ftpHistory']['cycling']);
+    }
+
+    public function testItAcceptsAnEmptyHistory(): void
+    {
+        $this->commandBus->dispatch(UpdateAthleteWeightHistory::fromPayload(['entries' => []]));
+
+        $this->assertSame([], $this->athlete()['weightHistory']);
+    }
+
+    public function testItThrowsOnMissingEntries(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('"entries" must be an array.');
+
+        UpdateAthleteWeightHistory::fromPayload([]);
+    }
+
+    public function testItThrowsOnANonObjectEntry(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Entry #0 must be an object.');
+
+        UpdateAthleteWeightHistory::fromPayload(['entries' => ['nope']]);
+    }
+
+    public function testItThrowsOnAMissingDate(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Entry #0 is missing a valid "on" date.');
+
+        UpdateAthleteWeightHistory::fromPayload(['entries' => [['weight' => 70]]]);
+    }
+
+    public function testItThrowsOnANonNumericWeight(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+        $this->expectExceptionMessage('Entry #0 is missing a valid numeric "weight".');
+
+        UpdateAthleteWeightHistory::fromPayload(['entries' => [['on' => '2024-01-01', 'weight' => 'heavy']]]);
+    }
+
+    public function testItThrowsOnAnInvalidDate(): void
+    {
+        $this->expectException(CouldNotDeserializeCommand::class);
+
+        UpdateAthleteWeightHistory::fromPayload(['entries' => [['on' => 'not-a-date', 'weight' => 70]]]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function athlete(): array
+    {
+        return $this->settingsRepository->find(SettingsGroup::GENERAL)['athlete'];
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commandBus = $this->getContainer()->get(CommandBus::class);
+        $this->settingsRepository = $this->getContainer()->get(KeyValueBasedSettingsRepository::class);
+    }
+}

--- a/tests/Infrastructure/Config/ApiTokenTest.php
+++ b/tests/Infrastructure/Config/ApiTokenTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Infrastructure\Config;
+
+use App\Infrastructure\Config\ApiToken;
+use PHPUnit\Framework\TestCase;
+
+class ApiTokenTest extends TestCase
+{
+    private const string VALID_TOKEN = 'a-token-that-is-long-enough-to-be-accepted';
+
+    public function testItMatchesTheConfiguredToken(): void
+    {
+        $this->assertTrue(ApiToken::fromString(self::VALID_TOKEN)->matches(self::VALID_TOKEN));
+    }
+
+    public function testItDoesNotMatchAnotherToken(): void
+    {
+        $this->assertFalse(ApiToken::fromString(self::VALID_TOKEN)->matches('something-else-entirely-but-long-enough'));
+    }
+
+    public function testAnEmptyTokenDisablesTheApi(): void
+    {
+        $this->assertFalse(ApiToken::fromString('')->isEnabled());
+    }
+
+    public function testADisabledTokenMatchesNothing(): void
+    {
+        // Not even the empty string, otherwise an unconfigured install would
+        // accept a request that sends no token at all.
+        $this->assertFalse(ApiToken::fromString('')->matches(''));
+    }
+
+    public function testItIgnoresSurroundingWhitespace(): void
+    {
+        $this->assertTrue(ApiToken::fromString('  '.self::VALID_TOKEN.'  ')->matches(self::VALID_TOKEN));
+    }
+
+    public function testWhitespaceOnlyCountsAsEmpty(): void
+    {
+        $this->assertFalse(ApiToken::fromString("   \n ")->isEnabled());
+    }
+
+    public function testItRejectsATokenThatIsTooShort(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API_TOKEN must be at least 32 characters long.');
+
+        ApiToken::fromString('too-short');
+    }
+
+    public function testItAcceptsATokenOfExactlyTheMinimumLength(): void
+    {
+        $this->assertTrue(ApiToken::fromString(str_repeat('a', 32))->isEnabled());
+    }
+}

--- a/tests/Infrastructure/Http/Gate/AdminAllowedIpGateTest.php
+++ b/tests/Infrastructure/Http/Gate/AdminAllowedIpGateTest.php
@@ -37,6 +37,23 @@ class AdminAllowedIpGateTest extends TestCase
         $gate->handle($request);
     }
 
+    public function testItDeniesApiAccessFromADisallowedIp(): void
+    {
+        // ADMIN_ALLOWED_IPS covers both routes into configuration: the admin
+        // panel and the configuration API.
+        $this->expectExceptionObject(new NotFoundHttpException('Not found'));
+
+        $gate = new AdminAllowedIpGate(AdminAllowedIpAddresses::fromString('192.168.1.1'));
+        $gate->handle($this->requestFromIp('/api/v1/config/athlete/weight-history', '10.0.0.1'));
+    }
+
+    public function testItAllowsApiAccessFromAnAllowedIp(): void
+    {
+        $gate = new AdminAllowedIpGate(AdminAllowedIpAddresses::fromString('192.168.1.1'));
+
+        $this->assertFalse($gate->handle($this->requestFromIp('/api/v1/config', '192.168.1.1'))->hasBeenApplied());
+    }
+
     public function testItAllowsEveryoneWhenNoAllowListIsConfigured(): void
     {
         $gate = new AdminAllowedIpGate(AdminAllowedIpAddresses::fromString(''));
@@ -59,11 +76,17 @@ class AdminAllowedIpGateTest extends TestCase
     {
         yield 'home' => ['/'];
         yield 'a path that merely starts with admin' => ['/administration'];
+        yield 'the pre-built api used by the frontend' => ['/api/activity/1/metrics.json'];
     }
 
     private function adminRequestFromIp(string $ipAddress): Request
     {
-        $request = Request::create('/admin/login');
+        return $this->requestFromIp('/admin/login', $ipAddress);
+    }
+
+    private function requestFromIp(string $path, string $ipAddress): Request
+    {
+        $request = Request::create($path);
         $request->server->set('REMOTE_ADDR', $ipAddress);
 
         return $request;

--- a/tests/Infrastructure/Http/Gate/ConditionalRedirectGateTest.php
+++ b/tests/Infrastructure/Http/Gate/ConditionalRedirectGateTest.php
@@ -19,6 +19,22 @@ class ConditionalRedirectGateTest extends TestCase
         $this->assertFalse($gate->handle(Request::create('/anything'))->hasBeenApplied());
     }
 
+    public function testItDefersForTheApiInsteadOfRedirecting(): void
+    {
+        // API clients need an actionable status code, not a 302 into the setup
+        // flow. Access-denying gates still apply, this only skips redirects.
+        $gate = $this->gate(shouldGuard: true);
+
+        $this->assertFalse($gate->handle(Request::create('/api/v1/config'))->hasBeenApplied());
+    }
+
+    public function testItStillRedirectsThePreBuiltApiUsedByTheFrontend(): void
+    {
+        $gate = $this->gate(shouldGuard: true);
+
+        $this->assertTrue($gate->handle(Request::create('/api/activity/1/metrics.json'))->hasBeenApplied());
+    }
+
     public function testItRedirectsANonAllowedPath(): void
     {
         $gate = $this->gate(shouldGuard: true);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

First off — thank you for this project. Dreeve is one of the most regularly used
tools in my homelab, and it has been running there happily for a long time. The
v5 migration was painless too: everything came across from my split
`config-*.yaml` files on the first boot.

So this comes from a place of wanting to build on something that already works
well, not from wanting it to be different.

New feature, no existing issue — happy to open one first if you would prefer to
discuss the shape before reviewing code.

Adds an opt-in HTTP API for reading and updating configuration, so settings that
originate outside Dreeve can be kept in sync without a human opening the admin
panel. My own motivation is a nightly job that pushes weight and resting heart
rate from an Apple Health export; today that means writing to the `KeyValue`
table directly, which is not something I want to depend on.

The emphasis is on the extension point rather than the six endpoints. Adding
configuration to the API should mean writing one class, not touching a
controller or routing.

### Design

`ConfigResource` is a tagged interface with `getName()` and `read()`.
`WritableConfigResource` extends it with `buildUpdateCommand()`. The registry
collects every tagged service, so a new resource is picked up automatically and
appears in the discovery endpoint with the methods it actually supports.

```
GET  /api/v1/config                                 # discovery
GET  /api/v1/config/athlete/weight-history
PUT  /api/v1/config/athlete/weight-history
GET  /api/v1/config/athlete/ftp-history/{cycling|running}
PUT  /api/v1/config/athlete/ftp-history/{cycling|running}
GET  /api/v1/config/athlete/max-heart-rate
PUT  /api/v1/config/athlete/max-heart-rate
GET  /api/v1/config/athlete/resting-heart-rate
PUT  /api/v1/config/athlete/resting-heart-rate
GET  /api/v1/config/zwift
PUT  /api/v1/config/zwift
```

Resources build a command and hand it back; the controller dispatches it. That
keeps validation in front of any write, and reuses the existing bus rather than
introducing a second write path. `ZwiftConfigResource` returns the existing
`UpdateSettings` instead of defining a command of its own, to show a resource
does not need bespoke machinery.

The write commands carry `#[RequiresRebuild]`, since weight, FTP and heart rate
all feed derived metrics.

### Authentication

Off by default. Setting `API_TOKEN` enables it; requests use
`Authorization: Bearer <token>`, handled by a stateless `api` firewall requiring
`ROLE_API`. Tokens shorter than 32 characters are rejected at boot rather than
quietly accepted.

`ADMIN_ALLOWED_IPS` now also covers `/api/v1`, so one setting restricts both
routes into configuration rather than leaving the API as an unguarded second
door for anyone already using the allowlist. **This changes the meaning of an
existing setting** — happy to split it into its own `API_ALLOWED_IPS` if you
would rather not overload it.

### Changes to existing behaviour

Three, all small, all deliberate:

1. **`ConditionalRedirectGate` defers for `/api/v1`.** Without it the setup-flow
   gates answer an API client with a 302 to a page it cannot render. Only
   redirects are skipped — `AdminAllowedIpGate` is not a redirect gate and still
   applies. Tests cover both directions, including that the prebuilt `/api/*`
   the frontend consumes is untouched.
2. **`AdminAllowedIpGate` guards `/api/v1` as well as `/admin`.**
3. **`FtpHistory` uses a new `FtpSport` enum** in place of its two private
   string constants, so the new code does not duplicate `'cycling'`/`'running'`.
   Pure refactor. Happy to pull this into a separate PR if you prefer.

### Validation

Reuses what already exists rather than parallel logic:

- `AthleteSettingsPayload::normalize()` handles the heart-rate payloads, so the
  API and the settings form agree on shape, coercion and duplicate-date
  rejection.
- FTP goes through `FtpHistory::fromArray()` with an explicitly keyed array, so
  the legacy-BC shim cannot be tripped by accident.
- Weight is validated with `AthleteWeightHistory::fromArray()`. Worth flagging:
  `GeneralSettings::fromArray()` stores `weightHistory` verbatim without
  validating it, so a bad entry currently surfaces much later at read time. The
  API validates up front rather than inheriting that.

Two smaller things the API had to be careful about, both of which are really
properties of the existing model:

- Stored weights are unit-ambiguous — a bare number interpreted via
  `AppearanceSettings`. `GET` returns the active `unit`, and `PUT` accepts an
  optional `unit` that must match, so a client cannot silently write pounds into
  a kilogram history.
- Updating `ftpHistory.cycling` must not wipe `running`. The commands are scoped
  per sport, and a pre-split history is migrated to the keyed shape rather than
  dropped.

### Not included

`integrations` is the obvious next candidate and is deliberately absent. The AI
config is already `#[\SensitiveParameter]` and notification services are
shoutrrr URLs with embedded credentials, so a `GET` would hand out API keys and
passwords to any token holder. That needs a redaction or write-only design
first. The read-only half of the interface exists partly to make that possible
later, and the interface contract states that `read()` must not expose secrets.
Same reasoning for `import.webhooks.verifyToken`.

`appearance`, `metrics` and `daemon` are omitted as human preferences with no
automation driver. `appearance.unitSystem` in particular would let a client flip
the meaning of every stored weight.

### Testing

2373 tests pass, plus the caddy suite. PHPStan level 8, rector and cs-fixer
clean. New code has no uncovered lines; overall line coverage goes from 98.77%
to 98.87%.

Coverage includes the auth paths, per-sport isolation, the legacy FTP shape, the
unit guard, and the read-only branch of the interface via a stub resource, since
every shipped resource is writable.

Also exercised against a live instance, which is where the imperial unit path
and the `#[RequiresRebuild]` flag actually got verified — a full weight history
round-tripped through the API byte-identical.

### Docs

New page at `docs/integrations/api.md`, registered in the sidebar, plus
`API_TOKEN` in the installation docs and `.env`.

### Disclosure

This PR was developed with AI assistance (Claude). The design decisions, the
review of what it produced, and the testing against a live instance are mine,
but the bulk of the implementation and test code was AI-written. Flagging it so
you can weight your review accordingly.

---

This is unsolicited, so if the shape is wrong for where you want the project to
go, say so and I will rework or drop it. The auth model and whether
`ADMIN_ALLOWED_IPS` should be overloaded are the two decisions I would most like
a second opinion on.
