### PR TITLE
Complete Hungarian (hu_HU) dashboard translations

### DIFF
--- a/translations/messages+intl-icu.hu_HU.yaml
+++ b/translations/messages+intl-icu.hu_HU.yaml
@@ -1,4 +1,4 @@
-'# completed': '# completed'
+'# completed': '# teljesítve'
 '42-day fitness trend': '42 napos fitnesz trend'
 '7-day fatigue level': '7 napos fáradtsági szint'
 '< 1.5: Good variety in training': '< 1,5: Jó változatosság az edzésben'
@@ -8,7 +8,7 @@
 'A high score means you concentrate more training into fewer, heavier days.': 'A magas pontszám azt jelenti, hogy több edzést koncentrálsz kevesebb, de nehezebb napra.'
 'A:C Ratio': 'A:C arány'
 'A:C optimal in': 'A:C optimális ezután:'
-'AI integration settings': 'AI integration settings'
+'AI integration settings': 'AI-integráció beállításai'
 'ATL (Fatigue)': 'ATL (Fáradtság)'
 'Accumulated fatigue': 'Felhalmozott fáradtság'
 'Active days': 'Aktív napok'
@@ -21,8 +21,8 @@ Activity: Tevékenység
 'Acute Training Load (Fatigue) - 7-day exponentially weighted average of your daily training load. Represents short-term fatigue.': 'Akut edzésterhelés (Fáradtság) – a napi edzésterhelés 7 napos exponenciálisan súlyozott átlaga. A rövid távú fáradtságot mutatja.'
 'Acute:Chronic Ratio - Ratio of ATL to CTL. Indicates injury risk.': 'Akut:Krónikus arány – az ATL és CTL aránya. Sérülésveszélyt jelöl.'
 'Adaptive & Inclusive Sports': 'Adaptív és inkluzív sportok'
-'Admin panel': 'Admin panel'
-'Aero sensor': 'Aero sensor'
+'Admin panel': 'Adminfelület'
+'Aero sensor': 'Aero szenzor'
 Afternoon: Délután
 All: Mind
 'All time': Összesített
@@ -30,54 +30,54 @@ All: Mind
 Apr: Ápr
 'Ask Mark something...': 'Kérdezz Marktól...'
 'Athlete profile': 'Sportoló profil'
-Aug: Aug
-Average: Average
+Aug: 'Aug'
+Average: 'Átlag'
 'Average gradient': 'Átlagos lejtés'
-'Avg gradient': 'Avg gradient'
-'Avg pace': 'Avg pace'
-'Avg speed': 'Avg speed'
+'Avg gradient': 'Átl. emelkedő'
+'Avg pace': 'Átl. tempó'
+'Avg speed': 'Átl. sebesség'
 'Back Country Ski': Túrasí
 Badges: Kitűzők
 Badminton: Tollaslabda
-Bananas: Bananas
+Bananas: 'Banán'
 Basketball: Kosárlabda
 Best: Legjobb
 'Best effort': 'Legjobb teljesítmény'
 'Best efforts': 'Legjobb teljesítmények'
 'Best efforts for {sportType}': 'Legjobb teljesítmények ({sportType})'
-'Bike light': 'Bike light'
-'Bike radar': 'Bike radar'
+'Bike light': 'Kerékpárlámpa'
+'Bike radar': 'Kerékpárradar'
 'Build zone (–10)': 'Építési zóna (–10)'
 'CTL (Fitness)': 'CTL (Fitnesz)'
 Cadence: Kadencia
-'Cadence sensor': 'Cadence sensor'
-Cal.: Cal.
+'Cadence sensor': 'Kadenciaszenzor'
+Cal.: 'Kal.'
 Calories: Kalória
 'Calories burned': 'Elégetett kalória'
-'Calories burnt': 'Calories burnt'
+'Calories burnt': 'Elégetett kalória'
 Canoeing: Kenuzás
 'Carbon saved': 'Megtakarított szén-dioxid'
 'Challenge consistency': 'Kihívás következetesség'
 Challenges: Kihívások
 'Chronic Training Load (Fitness) - 42-day exponentially weighted average of your daily training load. Represents long-term training adaptation.': 'Krónikus edzésterhelés (Fitnesz) – a napi edzésterhelés 42 napos exponenciálisan súlyozott átlaga. A hosszú távú edzésadaptációt mutatja.'
-'Clear all filters': 'Clear all filters'
+'Clear all filters': 'Összes szűrő törlése'
 'Clear chat': 'Chat törlése'
-Columns: Columns
-Commute: Commute
+Columns: 'Oszlopok'
+Commute: 'Ingázás'
 Commutes: Ingázások
 'Commutes only': 'Csak ingázások'
 Compare: Összehasonlítás
 'Compare to': 'Összehasonlítás:'
 'Completed {threshold} activities': '{threshold} tevékenység teljesítve'
-Components: Components
-'Configure gear maintenance': 'Configure gear maintenance'
-'Congrats! You achieved {numberOfPRs} PRs in this activity.': 'Congrats! You achieved {numberOfPRs} PRs in this activity.'
+Components: 'Komponensek'
+'Configure gear maintenance': 'Felszerelés-karbantartás beállítása'
+'Congrats! You achieved {numberOfPRs} PRs in this activity.': 'Gratulálunk! {numberOfPRs} egyéni rekordot értél el ebben a tevékenységben.'
 'Consider reducing load': 'Fontold meg a terhelés csökkentését'
 Consistency: Következetesség
 Country: Ország
 Cricket: Krikett
-Crossfit: Crossfit
-'Crunching the numbers...': 'Crunching the numbers...'
+Crossfit: 'Crossfit'
+'Crunching the numbers...': 'Számok ropogtatása...'
 'Current Status': 'Jelenlegi állapot'
 'Current streaks': 'Aktuális sorozatok'
 Cycling: Kerékpározás
@@ -90,52 +90,52 @@ Date: Dátum
 Day: Nap
 'Days needed': 'Szükséges napok'
 'Daytime stats': 'Napszaki statisztikák'
-Dec: Dec
-'Decreased compared to yesterday': 'Decreased compared to yesterday'
+Dec: 'Dec'
+'Decreased compared to yesterday': 'Csökkent a tegnapihoz képest'
 Density: Sűrűség
 Details: Részletek
 Device: Eszköz
-Dist.: Dist.
+Dist.: 'Táv.'
 Distance: Távolság
 'Distance & Elevation': 'Távolság & szintemelkedés'
-'Distance (single activity)': 'Distance (single activity)'
+'Distance (single activity)': 'Távolság (egy tevékenység)'
 'Distance breakdown': 'Távolság részletezés'
-'Distance distribution': 'Distance distribution'
+'Distance distribution': 'Távolság-eloszlás'
 'Distance in {unit}': 'Távolság ({unit})'
 'Distance over time per gear': 'Távolság időben felszerelésenkén'
 'Distance per month per gear': 'Havi távolság felszerelésenkén'
 'Doing a mix of cycling, running, swimming, and strength work increases your variety score.': 'A kerékpározás, futás, úszás és erőedzés vegyítése növeli a változatossági pontszámodat.'
 Duration: Időtartam
-'Dusting off the record books...': 'Dusting off the record books...'
-'E-Bike Ride': 'E-Bike Ride'
+'Dusting off the record books...': 'Rekordkönyvek leporolása...'
+'E-Bike Ride': 'E-bike kerékpározás'
 'E-Bike Rides': 'E-Bike túrák'
-'E-Mountain Bike Ride': 'E-Mountain Bike Ride'
+'E-Mountain Bike Ride': 'E-hegyikerékpározás'
 'E-Mountain Bike Rides': 'E-MTB túrák'
-Eddington: Eddington
-'Eddington number': 'Eddington number'
-'Eddington over time': 'Eddington over time'
-'Edit dashboard': 'Edit dashboard'
-'Edit this activity': 'Edit this activity'
+Eddington: 'Eddington'
+'Eddington number': 'Eddington-szám'
+'Eddington over time': 'Eddington az idő során'
+'Edit dashboard': 'Dashboard szerkesztése'
+'Edit this activity': 'Tevékenység szerkesztése'
 'Effort vs heart rate': 'Erőfeszítés vs pulzus'
-'Elapsed time': 'Elapsed time'
-'Electronic shifting': 'Electronic shifting'
+'Elapsed time': 'Eltelt idő'
+'Electronic shifting': 'Elektronikus váltó'
 Elev: Szintek
-Elev.: Elev.
+Elev.: 'Szint.'
 Elevation: Szintemelkedés
-'Elevation (single activity)': 'Elevation (single activity)'
+'Elevation (single activity)': 'Szintemelkedés (egy tevékenység)'
 'Elevation in {unit}': 'Szintemelkedés ({unit})'
 Elliptical: 'Elliptikus gép'
-Energy: Energy
-'Energy burned across your activities': 'Energy burned across your activities'
+Energy: 'Energia'
+'Energy burned across your activities': 'A tevékenységeid során elégetett energia'
 'Enter fullscreen mode': 'Teljes képernyős mód'
 Evening: Este
 'Excludes commutes': 'Ingázások nélkül'
-'Excludes group activities': 'Excludes group activities'
+'Excludes group activities': 'A csoportos tevékenységek kivételével'
 'FTP history': 'FTP előzmények'
-Fastest: Fastest
+Fastest: 'Leggyorsabb'
 Favourite: Kedvenc
-Feb: Feb
-'Filling up the bottles...': 'Filling up the bottles...'
+Feb: 'Febr'
+'Filling up the bottles...': 'Kulacsok feltöltése...'
 'Filter on KOM segments': 'Szűrés KOM szegmensekre'
 'Filter on country': 'Szűrés országra'
 'Filter on sport type': 'Szűrés sporttípusra'
@@ -147,13 +147,13 @@ Fitness: Fitnesz
 'Fitness may be declining due to low recent training load': 'A fitnesz csökkenhet az alacsony közelmúltbeli edzésterhelés miatt'
 'Fitness may decline': 'A fitnesz csökkenhet'
 'Foot pod': 'Foot pod'
-'For example, an Eddington number of 70 would imply that a cyclist has cycled at least 70 km or miles in a day on at least 70 occasions. Achieving a high Eddington number is difficult, since moving from, say, 70 to 75 will (probably) require more than five new long-distance workouts, since any workout shorter than 75 km or miles will no longer be included in the reckoning.': 'For example, an Eddington number of 70 would imply that a cyclist has cycled at least 70 km or miles in a day on at least 70 occasions. Achieving a high Eddington number is difficult, since moving from, say, 70 to 75 will (probably) require more than five new long-distance workouts, since any workout shorter than 75 km or miles will no longer be included in the reckoning.'
+'For example, an Eddington number of 70 would imply that a cyclist has cycled at least 70 km or miles in a day on at least 70 occasions. Achieving a high Eddington number is difficult, since moving from, say, 70 to 75 will (probably) require more than five new long-distance workouts, since any workout shorter than 75 km or miles will no longer be included in the reckoning.': 'Például egy 70-es Eddington-szám azt jelenti, hogy egy kerékpáros legalább 70 alkalommal tett meg naponta legalább 70 km-t vagy mérföldet. Magas Eddington-szám elérése nehéz, mert például a 70-ről 75-re lépés (valószínűleg) több mint öt új hosszútávú edzést igényel, hiszen a 75 km-nél vagy mérföldnél rövidebb edzések már nem számítanak bele.'
 'Form (TSB)': 'Forma (TSB)'
 Fri: P
-Fri.: Fri.
-'Front rings': 'Front rings'
-'Front shifts': 'Front shifts'
-GAP: GAP
+Fri.: 'Pén.'
+'Front rings': 'Első lánckerekek'
+'Front shifts': 'Első váltások'
+GAP: 'GAP'
 Gear: Felszerelés
 'Gear maintenance': 'Felszerelés karbantartás'
 'Gear stats': 'Felszerelés statisztikák'
@@ -161,22 +161,22 @@ Gear: Felszerelés
 'Gear that is retired is disabled by default.': 'A visszavont felszerelés alapértelmezés szerint le van tiltva.'
 'Go to activity': 'Ugrás a tevékenységhez'
 Goal: Cél
-Golf: Golf
+Golf: 'Golf'
 'Good training variety': 'Jó edzésváltozatosság'
 'Google searches': 'Google keresések'
-Grad.: Grad.
+Grad.: 'Emelk.'
 Gradient: Lejtés
-'Gravel Ride': 'Gravel Ride'
+'Gravel Ride': 'Gravel kerékpározás'
 'Gravel Rides': 'Gravel túrák'
-'Group activities': 'Group activities'
-'Group activities only': 'Group activities only'
-'Group activity': 'Group activity'
+'Group activities': 'Csoportos tevékenységek'
+'Group activities only': 'Csak csoportos tevékenységek'
+'Group activity': 'Csoportos tevékenység'
 "Guidelines vary by individual; for more information see Joe Friel's 'The Cyclist's Training Bible' or TrainingPeaks' research documentation.": "Az irányelvek egyénenként változnak; további információkért lásd Joe Friel 'The Cyclist's Training Bible' c. könyvét vagy a TrainingPeaks kutatási dokumentációját."
-HIIT: HIIT
+HIIT: 'HIIT'
 HR: Pulzus
 'Hand Cycle': Kézikerékpár
 'Heart rate': Pulzus
-'Heart rate monitor': 'Heart rate monitor'
+'Heart rate monitor': 'Pulzusmérő'
 'Heart rate zone distribution over the past month. For effective polarized training, your workouts should primarily fall within the following zones': 'Az elmúlt havi pulzuszóna eloszlás. A hatékony polarizált edzéshez az edzéseidnek elsősorban a következő zónákba kell esniük'
 'Heart rate zones': Pulzuszónák
 Heatmap: Hőtérkép
@@ -186,7 +186,7 @@ High: Magas
 'High risk': 'Magas kockázat'
 'Highlight visited countries': 'Meglátogatott országok kiemelése'
 'Highly recovered and ready to perform': 'Teljesen regenerálódva, készen a teljesítésre'
-Hike: Hike
+Hike: 'Túra'
 Hikes: Túrák
 History: Előzmények
 'History (6 weeks)': 'Előzmények (6 hét)'
@@ -199,25 +199,25 @@ History: Előzmények
 'Ice Skate': Jégkorcsolya
 Imperial: Angolszász
 "In that time, I’ve covered {totalDistance}, that's {numberOfTripsAroundTheWorld} trips around the world 🌍 or {numberOfTripsToTheMoonPercent}% of the way to the moon 🌕, and climbed an elevation of {totalElevation} which is {timesMountEverest} times Mount Everest 🏔. All up that's {totalTimeRecorded} of moving time 🎉.": 'Ez idő alatt {totalDistance}-t tettem meg, ami {numberOfTripsAroundTheWorld} körülutazás a Föld körül, vagy {numberOfTripsToTheMoonPercent}% az úton a Hold felé, és {totalElevation} szintemelkedést győztem le, ami {timesMountEverest}-szer a Mount Everest magassága. Összesen {totalTimeRecorded} mozgásban töltött idő.'
-'Increased compared to yesterday': 'Increased compared to yesterday'
+'Increased compared to yesterday': 'Nőtt a tegnapihoz képest'
 'Individual thresholds vary based on fitness level.': 'Az egyéni küszöbértékek a fitnesz szinttől függően változnak.'
 'Inline Skate': Görkorcsolya
 Intensity: Intenzitás
-Jan: Jan
+Jan: 'Jan'
 Jul: Júl
 Jun: Jún
-KOM: KOM
+KOM: 'KOM'
 Kayaking: Kajak
 'Kite Surf': 'Sárkányos szörfözés'
 Lap: Kör
-'Last 30 days': 'Last 30 days'
+'Last 30 days': 'Utolsó 30 nap'
 'Last 7 days training load': 'Utolsó 7 nap edzésterhelése'
 'Last activity': 'Utolsó tevékenység'
 'Last effort': 'Utolsó teljesítmény'
 'Last effort date': 'Utolsó teljesítmény dátuma'
 'Last maintenance': 'Utolsó karbantartás'
-'Last month': 'Last month'
-'Last week': 'Last week'
+'Last month': 'Előző hónap'
+'Last week': 'Előző hét'
 'Last {numberOfDays} days': 'Utolsó {numberOfDays} nap'
 Lifetime: 'Teljes időszak'
 'Light fatigue with good readiness. A great balance for quality training or longer efforts': 'Enyhe fáradtság jó készenléti állapottal. Kiváló egyensúly a minőségi edzéshez vagy hosszabb erőfeszítésekhez'
@@ -228,49 +228,49 @@ Loading...: Betöltés...
 'Long run': 'Hosszú futás'
 'Longest activity': 'Leghosszabb tevékenység'
 'Longest activity (h)': 'Leghosszabb tevékenység (h)'
-'Longest day': 'Longest day'
+'Longest day': 'Leghosszabb nap'
 'Longest distance': 'Leghosszabb távolság'
 'Longest streaks': 'Leghosszabb sorozatok'
 Low: Alacsony
 'Low risk': 'Alacsony kockázat'
 'Low training load': 'Alacsony edzésterhelés'
 Maintenance: Karbantartás
-'Manage activities': 'Manage activities'
-'Manage gear': 'Manage gear'
-'Manage recording devices': 'Manage recording devices'
-'Map settings': 'Map settings'
+'Manage activities': 'Tevékenységek kezelése'
+'Manage gear': 'Felszerelések kezelése'
+'Manage recording devices': 'Rögzítő eszközök kezelése'
+'Map settings': 'Térkép beállításai'
 Mar: Már
-Max: Max
+Max: 'Max'
 'Max gradient': 'Max. lejtés'
 May: Máj
 Medium: Közepes
 Metric: Metrikus
-'Metrics settings': 'Metrics settings'
+'Metrics settings': 'Mérőszámok beállításai'
 Milestones: Mérföldkövek
 'Mind & Body Sports': 'Test-lélek sportok'
 'Moderate fatigue with stable fitness. Well suited for consistent day-to-day training': 'Mérsékelt fáradtság stabil fittséggel. Kiváló a következetes napi edzéshez'
 'Moderate monotony': 'Mérsékelt monotonitás'
 Mon: H
-Mon.: Mon.
+Mon.: 'Hét.'
 Monotony: Monotonitás
 Monthly: Havi
 'Monthly stats': 'Havi statisztikák'
 Morning: Reggel
 'Most elevation': 'Legtöbb szintemelkedés'
 'Most recent activities': 'Legutóbbi tevékenységek'
-'Most recent activities with map': 'Most recent activities with map'
+'Most recent activities with map': 'Legutóbbi tevékenységek térképpel'
 'Most recent challenges': 'Legutóbbi kihívások'
 'Most recent milestones': 'Legutóbbi mérföldkövek'
-'Mountain Bike Ride': 'Mountain Bike Ride'
+'Mountain Bike Ride': 'Hegyikerékpározás'
 'Mountain Bike Rides': 'MTB túrák'
 'Moving time': 'Mozgásban töltött idő'
-'Moving time by sport': 'Moving time by sport'
-'Moving time in hours': 'Moving time in hours'
-'Muscle oxygen sensor': 'Muscle oxygen sensor'
+'Moving time by sport': 'Mozgásidő sportáganként'
+'Moving time in hours': 'Mozgásidő órában'
+'Muscle oxygen sensor': 'Izomoxigén-szenzor'
 Name: Név
 Neutral: Semleges
 'New personal best for': 'Új személyes rekord:'
-'Next milestone': 'Next milestone'
+'Next milestone': 'Következő mérföldkő'
 Night: Éjjel
 'No activities': 'Nincsenek tevékenységek'
 'No data available': 'Nincs elérhető adat'
@@ -278,68 +278,68 @@ Night: Éjjel
 'No other options to compare with': 'Nincs más összehasonlítási lehetőség'
 None: 'Egyik sem'
 'Nordic Ski': Sífutás
-'Normalized power': 'Normalized power'
+'Normalized power': 'Normalizált teljesítmény'
 'Not supported': 'Nem támogatott'
-Nov: Nov
+Nov: 'Nov'
 Now: Most
-'Number of activities': 'Number of activities'
+'Number of activities': 'Tevékenységek száma'
 'Number of activities per month': 'Havi tevékenységek száma'
 'Number of times completed': 'Teljesítések száma'
 Oct: Okt
 'Older effort': 'Korábbi teljesítmény'
 'On average, that works out to {dailyAverage} per day, a weekly average of {weeklyAverage} and a monthly average of {monthlyAverage} 🐣.': 'Átlagosan ez {dailyAverage} naponta, heti átlag {weeklyAverage} és havi átlag {monthlyAverage}.'
-'On your own': 'On your own'
+'On your own': 'Egyedül'
 'One of your gear maintenance tasks is due': 'Az egyik felszerelés karbantartási feladatod esedékes'
-"Oops, looks like you've wandered off the map! 🗺️": "Oops, looks like you've wandered off the map! 🗺️"
-'Open Water Swim': 'Open Water Swim'
+'Oops, looks like you''ve wandered off the map! 🗺️': 'Hoppá, úgy tűnik, letértél a térképről! 🗺️'
+'Open Water Swim': 'Nyíltvízi úszás'
 'Optimal training range': 'Optimális edzéstartomány'
 Other: Egyéb
 'Outdoor Sports': 'Szabadtéri sportok'
 Over-fatigued: Túlterhelve
 'Over-fatigued (–30)': 'Túlterhelve (–30)'
 'Overall weekly training stress': 'Heti összes edzésstressz'
-'Overdue by {amount}': 'Overdue by {amount}'
+'Overdue by {amount}': '{amount} késésben'
 'PB badges': 'Személyes rekord kitűzők'
 'PET bottles produced': 'Előállított PET palackok'
 Pace: Tempó
-Padel: Padel
+Padel: 'Padel'
 'Peak fresh': Csúcsfriss
 'Peak power outputs': 'Csúcsteljesítmény értékek'
 'Per {unit}': 'Per {unit}'
 'Personal bests': 'Személyes csúcsok'
 Photo: Fotó
 Photos: Fotók
-'Physical Therapy': 'Physical Therapy'
+'Physical Therapy': 'Gyógytorna'
 'Pickle Ball': Pickleball
-Pilates: Pilates
-'Pizza slices': 'Pizza slices'
+Pilates: 'Pilates'
+'Pizza slices': 'Pizzaszeletek'
 'Polarised training (last 30 days)': 'Polarizált edzés (utolsó 30 nap)'
-'Pool Swim': 'Pool Swim'
+'Pool Swim': 'Medencés úszás'
 Power: Teljesítmény
-'Power meter': 'Power meter'
+'Power meter': 'Teljesítménymérő'
 'Powered by an estimated {caloriesBurned} calories, or roughly {numberOfPizzaSlices} slices of pizza 🍕.': 'Ezt becsült {caloriesBurned} kalória hajtotta, ami nagyjából {numberOfPizzaSlices} szelet pizza.'
 'Prev year': 'Előző év'
 Previous: Előző
-'Purchase price': 'Purchase price'
+'Purchase price': 'Vételár'
 Race: Verseny
 'Racing Score': Versenypontszám
 'Racquet & Paddle Sports': 'Ütős sportok'
 'Racquet Ball': 'Squash labda'
-Rank: Rank
+Rank: 'Helyezés'
 Ranking: Ranglista
 'Reached {threshold} hours total moving time': '{threshold} óra összes mozgásidő elérve'
 'Reached {threshold} total distance': '{threshold} összes távolság elérve'
 'Reached {threshold} total elevation': '{threshold} összes szintemelkedés elérve'
-'Rear cogs': 'Rear cogs'
-'Rear shifts': 'Rear shifts'
-'Recalculating your suffer score...': 'Recalculating your suffer score...'
-Recent: Recent
+'Rear cogs': 'Hátsó fogaskerekek'
+'Rear shifts': 'Hátsó váltások'
+'Recalculating your suffer score...': 'Szenvedéspontszám újraszámítása...'
+Recent: 'Legutóbbi'
 'Recent effort': 'Közelmúltbeli teljesítmény'
 'Recording devices': 'Rögzítő eszközök'
 'Recovery Timeline': 'Regenerációs idővonal'
 'Recovery forecast': 'Regenerációs előrejelzés'
 'Reduced carbon emission by commuting': 'Csökkentett szén-dioxid kibocsátás ingázással'
-'Register maintenance': 'Register maintenance'
+'Register maintenance': 'Karbantartás rögzítése'
 'Relative cost': 'Relatív költség'
 'Rest Days': Pihenőnapok
 'Rest days': Pihenőnapok
@@ -348,44 +348,44 @@ Recent: Recent
 'Retired gear': 'Visszavont felszerelés'
 Rewind: Visszatekintő
 'Rewind comparisons are only available on larger screens.': 'A visszatekintő összehasonlítások csak nagyobb képernyőkön érhetők el.'
-Ride: Ride
+Ride: 'Kerékpározás'
 Rides: 'Kerékpáros túrák'
 'Risk of detraining': 'Edzettség elvesztésének kockázata'
 'Rock Climbing': Sziklamászás
 'Roller Ski': 'Görkorcsolyás sí'
 Rowing: Evezés
-Run: Run
+Run: 'Futás'
 Running: Futás
 Runs: Futások
 Sail: Vitorlázás
 Sat: Szo
-Sat.: Sat.
+Sat.: 'Szo.'
 Search: Keresés
 'Search activity...': 'Tevékenység keresése...'
 'Search segment...': 'Szegmens keresése...'
 Segments: Szegmensek
 Sep: Szept
-Shifting: Shifting
-'Show all columns': 'Show all columns'
+Shifting: 'Váltás'
+'Show all columns': 'Összes oszlop megjelenítése'
 'Show information': 'Információ megjelenítése'
 'Shows how your TSB (Form) and A:C Ratio will recover over time if you take complete rest days.': 'Megmutatja, hogyan fog a TSB (Forma) és az A:C arány idővel helyreállni, ha teljes pihenőnapokat tartasz.'
-'Similar activities': 'Similar activities'
-"Since I began working out {numberOfDaysAgo} ago on {startDate}, I've logged {totalDaysOfWorkingOut} active days of training and adventure.": "Since I began working out {numberOfDaysAgo} ago on {startDate}, I've logged {totalDaysOfWorkingOut} active days of training and adventure."
+'Similar activities': 'Hasonló tevékenységek'
+'Since I began working out {numberOfDaysAgo} ago on {startDate}, I''ve logged {totalDaysOfWorkingOut} active days of training and adventure.': 'Mióta {numberOfDaysAgo} ezelőtt, {startDate} napon elkezdtem edzeni, {totalDaysOfWorkingOut} aktív edzés- és kalandnapot rögzítettem.'
 Skateboard: Gördeszkázás
 Skating: Korcsolyázás
 'Slightly fresh': 'Kissé friss'
-'Smart trainer': 'Smart trainer'
-Snowboard: Snowboard
+'Smart trainer': 'Okosgörgő'
+Snowboard: 'Snowboard'
 Snowshoe: Hótalp
 Soccer: Labdarúgás
 'Someone who regularly trains for 90 minutes will score higher than someone doing mostly short sessions.': 'Aki rendszeresen 90 percet edz, magasabb pontszámot ér el, mint aki főleg rövid edzéseket végez.'
-Sort: Sort
+Sort: 'Rendezés'
 Speed: Sebesség
-'Speed & cadence sensor': 'Speed & cadence sensor'
-'Speed sensor': 'Speed sensor'
+'Speed & cadence sensor': 'Sebesség- és kadenciaszenzor'
+'Speed sensor': 'Sebességszenzor'
 Splits: Részidők
 'Sport variety': Sporttípus-változatosság
-Squash: Squash
+Squash: 'Squash'
 'Stair Stepper': 'Lépcső szimulátor'
 'Stand Up Paddling': SUP
 'Start times': 'Kezdési idők'
@@ -394,15 +394,15 @@ Status: Állapot
 'Streak started on {date}': 'Sorozat kezdete: {date}'
 Streaks: Sorozatok
 Sun: V
-Sun.: Sun.
+Sun.: 'Vas.'
 Surfing: Szörfözés
 'TSB (Form)': 'TSB (Forma)'
 'TSB positive in': 'TSB pozitív ezután:'
 'Table Tennis': Asztalitenisz
 'Taper sweet-spot (+15)': 'Taper édes pont (+15)'
 'Team Sports': Csapatsportok
-Temperature: Temperature
-'Temperature sensor': 'Temperature sensor'
+Temperature: 'Hőmérséklet'
+'Temperature sensor': 'Hőmérséklet-szenzor'
 Tennis: Tenisz
 "That's 1.5 times the distance to the edge of space": 'Ez 1,5-szere az űr határáig terjedő távolságnak'
 "That's 100 days of commitment, triple digits!": 'Ez 100 nap elkötelezettség, háromjegyű!'
@@ -491,31 +491,31 @@ Tennis: Tenisz
 "That's the length of the Great Wall of China": 'Ez a Kínai Nagy Fal hossza'
 "That's three quarters of the way around the Earth": 'Ez a Föld kerületének háromnegyede'
 "That's {number} days of at least {distance}": 'Ez {number} nap legalább {distance}-vel'
-"That's {percentage}% of all countries 🌍": "That's {percentage}% of all countries 🌍"
-'The Eddington number in the context of cycling or running is defined as the maximum number E such that the athlete has covered at least E km on at least E days.': 'The Eddington number in the context of cycling or running is defined as the maximum number E such that the athlete has covered at least E km on at least E days.'
-"The page you're looking for doesn't exist or may have been moved.": "The page you're looking for doesn't exist or may have been moved."
+'That''s {percentage}% of all countries 🌍': 'Ez az összes ország {percentage}%-a 🌍'
+'The Eddington number in the context of cycling or running is defined as the maximum number E such that the athlete has covered at least E km on at least E days.': 'Az Eddington-szám kerékpározás vagy futás esetén az a legnagyobb E szám, amelyre igaz, hogy a sportoló legalább E napon legalább E km-t tett meg.'
+'The page you''re looking for doesn''t exist or may have been moved.': 'A keresett oldal nem létezik, vagy áthelyezték.'
 'These badges are dynamically created. You can use them in any &lt;img&gt; tag': 'Ezek a kitűzők dinamikusan jönnek létre. Bármely &lt;img&gt; tagben használhatod őket'
 Thinking...: Gondolkodás...
 'This chart summarizes how you train. Each axis reflects a different normalized training habit, so higher values mean stronger emphasis.': 'Ez a diagram összefoglalja, hogyan edzel. Minden tengely különböző normalizált edzési szokást tükröz, így a magasabb értékek erősebb hangsúlyt jelentenek.'
 'This feature is currently disabled': 'Ez a funkció jelenleg le van tiltva'
-'This month': 'This month'
-'This week': 'This week'
+'This month': 'Ez a hónap'
+'This week': 'Ez a hét'
 Thu: Cs
-Thu.: Thu.
+Thu.: 'Csüt.'
 Time: Idő
-'Time in gear': 'Time in gear'
-'Time in zone': 'Time in zone'
+'Time in gear': 'Idő a felszereléssel'
+'Time in zone': 'Idő a zónában'
 'Times completed': 'Teljesítések száma'
-Title: Title
-'To enable it, configure this in the admin panel': 'To enable it, configure this in the admin panel'
+Title: 'Cím'
+'To enable it, configure this in the admin panel': 'Az engedélyezéséhez állítsd be az adminfelületen'
 'Toggle sidebar': 'Oldalsáv ki/be'
 'Top 10': 'Top 10'
 'Total distance per month': 'Havi össztávolság'
 'Total elevation per month': 'Havi össz szintemelkedés'
 'Total hours spent per gear': 'Összes óra felszerelésenkén'
 'Total hours spent per sport type': 'Összes óra sporttípusonként'
-'Total moving time per month': 'Total moving time per month'
-'Trail Run': 'Trail Run'
+'Total moving time per month': 'Teljes mozgásidő havonta'
+'Trail Run': 'Terepfutás'
 'Trail Runs': Terepfutások
 'Training 4–5 days every week scores higher than doing everything in one or two days.': 'A heti 4–5 napos edzés magasabb pontszámot ér el, mint ha mindent egy-két napra zsúfolnak.'
 'Training Impulse - Training load metric that accounts for intensity and duration.': 'Edzési impulzus – az intenzitást és az időtartamot figyelembe vevő edzésterhelési mutató.'
@@ -525,33 +525,33 @@ Title: Title
 'Training goals': 'Edzési célok'
 'Training load is accumulating, recovery days are important': 'Az edzésterhelés halmozódik, a regenerációs napok fontosak'
 Tue: K
-Tue.: Tue.
-'Unchanged compared to yesterday': 'Unchanged compared to yesterday'
+Tue.: 'Kedd'
+'Unchanged compared to yesterday': 'Változatlan a tegnapihoz képest'
 Unspecified: Meghatározatlan
-'Upcoming maintenance': 'Upcoming maintenance'
+'Upcoming maintenance': 'Közelgő karbantartás'
 'User badge': 'Felhasználói kitűző'
-'Velo Mobile': 'Velo Mobile'
+'Velo Mobile': 'Velomobil'
 'Velo Mobiles': Velomobil
 'Very high': 'Nagyon magas'
 'View all': 'Összes megtekintése'
 'View details': 'Részletek megtekintése'
-'View this month': 'View this month'
-'Virtual Ride': 'Virtual Ride'
+'View this month': 'Ez a hónap megtekintése'
+'Virtual Ride': 'Virtuális kerékpározás'
 'Virtual Rides': 'Virtuális kerékpározás'
 'Virtual Row': 'Virtuális evezés'
-'Virtual Run': 'Virtual Run'
+'Virtual Run': 'Virtuális futás'
 'Virtual Runs': 'Virtuális futások'
 'Virtual workout assistant': 'Virtuális edzési asszisztens'
 Volleyball: Röplabda
 Volume: Mennyiség
-Walk: Walk
+Walk: 'Séta'
 Walking: Gyaloglás
 Walks: Séták
 'Water Sports': 'Vízi sportok'
-'Waxing the chain...': 'Waxing the chain...'
+'Waxing the chain...': 'Lánc viaszolása...'
 'We detected following issues': 'A következő problémákat észleltük'
 Wed: Sze
-Wed.: Wed.
+Wed.: 'Szer.'
 Weekly: Heti
 'Weekly Strain': 'Heti terhelés'
 'Weekly Strain - Product of weekly training load and monotony. Overall training stress.': 'Heti terhelés – a heti edzésterhelés és a monotonitás szorzata. Összesített edzési stressz.'
@@ -563,28 +563,28 @@ Weight: Súly
 Wheelchair: Kerekesszék
 'Wind Surf': Windsurfing
 'Winter Sports': 'Téli sportok'
-'With others': 'With others'
+'With others': 'Másokkal'
 Workout: Edzés
 'Workout assistant': 'Edzési asszisztens'
 'Workout type': 'Edzés típusa'
-World: World
+World: 'Világ'
 Year: Év
 Yearly: Éves
 'Yearly stats': 'Éves statisztikák'
 Yoga: Jóga
-"You weren't alone out there": "You weren't alone out there"
+'You weren''t alone out there': 'Nem voltál egyedül odakint'
 'Your Dreeve badge': 'Dreeve kitűződ'
 'Your PB badge': 'Személyes rekord kitűződ'
 'Your Zwift badge': 'Zwift kitűződ'
 'Your badge(s)': Kitűződ(ök)
-Z1: Z1
+Z1: 'Z1'
 'Z1-2 (Low)': 'Z1-2 (Alacsony)'
-Z2: Z2
-Z3: Z3
+Z2: 'Z2'
+Z3: 'Z3'
 'Z3 (Mod)': 'Z3 (Közepes)'
-Z4: Z4
+Z4: 'Z4'
 'Z4-5 (High)': 'Z4-5 (Magas)'
-Z5: Z5
+Z5: 'Z5'
 'Zone 1 (recovery)': '1. zóna (regeneráció)'
 'Zone 2 (aerobic)': '2. zóna (aerob)'
 'Zone 3 (aerobic/anaerobic)': '3. zóna (aerob/anaerob)'
@@ -596,49 +596,49 @@ Z5: Z5
 activities: tevékenységek
 and: és
 avg: átl
-bpm: bpm
+bpm: 'bpm'
 clear: törlés
 compare: összehasonlítás
-countries: countries
+countries: 'ország'
 day(s): nap(ok)
 days: napok
 'days needed for next Eddington': 'napok a következő Eddington-számhoz'
-'days to reach {n}': 'days to reach {n}'
-'every {interval}': 'every {interval}'
+'days to reach {n}': 'nap a(z) {n} eléréséig'
+'every {interval}': 'minden {interval}'
 hours: órák
 hrs: h
-humidity: humidity
+humidity: 'páratartalom'
 'last {numberOfDays} days': 'utolsó {numberOfDays} nap'
-max: max
-min: min
+max: 'max'
+min: 'min'
 months: hónapok
 more: több
-n/a: n/a
+n/a: 'n/a'
 never: soha
-'of your activities': 'of your activities'
+'of your activities': 'a tevékenységeidből'
 'on': 'ekkor:'
 per: /
 'per activity': tevékenységenkén
 'per hour': óránként
 'reached Eddington number {number}': '{number}-es Eddington-szám elérve'
-rpm: rpm
+rpm: 'rpm'
 to: '-ig'
 total: összesen
-watts: watts
+watts: 'watt'
 weeks: hetek
 workouts: edzések
-'{amount} left': '{amount} left'
+'{amount} left': 'még {amount}'
 '{daysSinceLastTagged} days': '{daysSinceLastTagged} nap'
 '{days} consecutive days of activity': '{days} egymást követő aktív nap'
 '{hoursSinceLastTagged} hours': '{hoursSinceLastTagged} óra'
 '{maintenanceTaskLabel} every {interval}': '{maintenanceTaskLabel} minden {interval}'
 '{numberOfActivities} activities': '{numberOfActivities} tevékenység'
 '{numberOfActivities} activities in {year}': '{numberOfActivities} tevékenység {year}-ben'
-'{numberOfActivities} activities on this route': '{numberOfActivities} activities on this route'
+'{numberOfActivities} activities on this route': '{numberOfActivities} tevékenység ezen az útvonalon'
 '{numberOfMonths} months': '{numberOfMonths} hónap'
-'{numberOfResults} photos': '{numberOfResults} photos'
-'{numberOfResults} results': '{numberOfResults} results'
-'{numberOfResults} routes': '{numberOfResults} routes'
+'{numberOfResults} photos': '{numberOfResults} fotó'
+'{numberOfResults} results': '{numberOfResults} találat'
+'{numberOfResults} routes': '{numberOfResults} útvonal'
 '{numberOfWeeks} weeks': '{numberOfWeeks} hét'
 '{threshold} hours using {gearName}': '{threshold} óra {gearName} felhasználásával'
 '{threshold} total distance using {gearName}': '{threshold} össztávolság {gearName} felhasználásával'


### PR DESCRIPTION
## What

Follow-up to #2626 (which completed the admin panel). This fills in the remaining ~165 untranslated strings in `messages+intl-icu.hu_HU.yaml`, so the public dashboard is now fully Hungarian.

Covers: sport types, sensors, month/weekday abbreviations, zone & unit labels, loading messages, and a few sentences (Eddington explanation, share text, etc.).

## Notes

- **ICU placeholders** (`{numberOfPRs}`, `{percentage}`, `{numberOfResults}`, `{amount}`, `{interval}`, …) are kept intact.
- **Brand / technical terms** left as-is: `GAP`, `KOM`, `Eddington`, zones `Z1`–`Z5`, units `bpm`/`rpm`, and sport names that are loanwords in Hungarian (Crossfit, HIIT, Pilates, Padel, Squash, Golf, Snowboard…).
- **Month abbreviations** follow the style already in the file (`Már`, `Ápr`, `Szept`…); the ones identical in Hungarian (Jan, Aug, Nov, Dec) are left unchanged.
- Only values changed; keys are untouched. Feel free to run `app:translations:extract` to normalize formatting.

Happy to adjust any wording a native reviewer would phrase differently. 🇭🇺